### PR TITLE
support des fichiers ccd pour la pce et psx

### DIFF
--- a/board/recalbox/fsoverlay/root/.emulationstation/es_systems.cfg
+++ b/board/recalbox/fsoverlay/root/.emulationstation/es_systems.cfg
@@ -94,7 +94,7 @@
         <fullname>Sega CD</fullname>
         <name>segacd</name>
         <path>/recalbox/share/roms/segacd</path>
-        <extension>.cue .CU .iso .ISO</extension>
+        <extension>.cue .CUE .iso .ISO</extension>
         <command>python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.pyc %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM%</command>
         <platform>segacd</platform>
         <theme>segacd</theme>
@@ -139,7 +139,7 @@
         <fullname>Sony Playstation 1</fullname>
         <name>psx</name>
         <path>/recalbox/share/roms/psx</path>
-        <extension>.img .IMG .pbp .PBP .bin .BIN .cue .CUE .iso .ISO</extension>
+        <extension>.img .IMG .pbp .PBP .bin .BIN .cue .CUE .iso .ISO .ccd .CCD</extension>
         <command>python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.pyc %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM%</command>
         <!--<command>python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.pyc %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM%</command>-->
         <platform>psx</platform>
@@ -149,7 +149,7 @@
         <fullname>PC Engine</fullname>
         <name>pcengine</name>
         <path>/recalbox/share/roms/pcengine</path>
-        <extension>.pce .PCE .cue .CUE .sgx .SGX .zip .ZIP</extension>
+        <extension>.pce .PCE .cue .CUE .sgx .SGX .zip .ZIP .ccd .CCD</extension>
 	<command>python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.pyc %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM%</command>
 	<platform>pcengine</platform>
         <theme>pcengine</theme>


### PR DESCRIPTION
ajout de la detection des images au format ccd pour la pc engine et la playstation et une correction (CUE) pour le sega cd
