### PR TITLE
Enable MAD and VORBIS supports (Scummvm)

### DIFF
--- a/board/recalbox/fsoverlay/root/.emulationstation/es_systems.cfg
+++ b/board/recalbox/fsoverlay/root/.emulationstation/es_systems.cfg
@@ -22,7 +22,7 @@
         <fullname>Nintendo 64</fullname>
         <name>n64</name>
         <path>/recalbox/share/roms/n64</path>
-        <extension>.n64 .N64 .zip .ZIP .z64 .Z64 .v64 .V64</extension>
+        <extension>.n64 .N64 .z64 .Z64 .v64 .V64</extension>
         <command>/recalbox/scripts/emulatorlauncher.sh %ROM% "n64"</command>
         <platform>n64</platform>
         <theme>n64</theme>

--- a/package/scummvm-vanfanel/scummvm-vanfanel.mk
+++ b/package/scummvm-vanfanel/scummvm-vanfanel.mk
@@ -47,7 +47,7 @@ define SCUMMVM_VANFANEL_CONFIGURE_CMDS
 		OPENGL_CFLAGS="$(SCUMMVM_VANFANEL_ADDITIONAL_FLAGS)" \
 		OPENGL_LIBS="$(SCUMMVM_VANFANEL_ADDITIONAL_FLAGS)" \
                 ./configure \
-		--enable-gles-rpi --disable-debug --enable-release --enable-optimizations --disable-mt32emu --enable-flac --disable-mad --disable-vorbis --disable-tremor \
+		--enable-gles-rpi --disable-debug --enable-release --enable-optimizations --disable-mt32emu --enable-flac --enable-mad --enable-vorbis --disable-tremor \
 		--disable-fluidsynth --disable-taskbar --disable-timidity --disable-alsa \
                 --prefix=/usr --host=arm --with-sdl-prefix="$(STAGING_DIR)/usr/bin/" --enable-release --host=arm-linux-gnueabi \
         )	


### PR DESCRIPTION
MAD Vorbis allow the use of compressed audio files in ScummVM package

http://scummvm.org/links/ :
MAD is a high-quality MPEG (MP3) audio decoder. ScummVM optionally supports playback of CD tracks and other audio data encoded using MP3.
Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format. ScummVM optionally supports playback of CD tracks and other audio data encoded using Ogg Vorbis.

Dependencies required libraries are already present in the make.
