### PR TITLE
Joysticks support improvement, including wiimote

### DIFF
--- a/board/recalbox/fsoverlay/etc/udev/rules.d/99-wiimote.rules
+++ b/board/recalbox/fsoverlay/etc/udev/rules.d/99-wiimote.rules
@@ -1,2 +1,2 @@
 SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
-
+SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"

--- a/board/recalbox/fsoverlay/etc/udev/rules.d/99-wiimote.rules
+++ b/board/recalbox/fsoverlay/etc/udev/rules.d/99-wiimote.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
+

--- a/board/recalbox/kernel_patches_3.19/linux-wiimote-abs-not-hat.patch
+++ b/board/recalbox/kernel_patches_3.19/linux-wiimote-abs-not-hat.patch
@@ -1,0 +1,54 @@
+--- a/drivers/hid/hid-wiimote-modules.c
++++ b/drivers/hid/hid-wiimote-modules.c
+1117,1122c1117,1122
+< 	input_report_abs(wdata->extension.input, ABS_HAT1X, lx - 0x20);
+< 	input_report_abs(wdata->extension.input, ABS_HAT1Y, ly - 0x20);
+< 	input_report_abs(wdata->extension.input, ABS_HAT2X, rx - 0x20);
+< 	input_report_abs(wdata->extension.input, ABS_HAT2Y, ry - 0x20);
+< 	input_report_abs(wdata->extension.input, ABS_HAT3X, rt);
+< 	input_report_abs(wdata->extension.input, ABS_HAT3Y, lt);
+---
+> 	input_report_abs(wdata->extension.input, ABS_X, lx - 0x20);
+> 	input_report_abs(wdata->extension.input, ABS_Y, ly - 0x20);
+> 	input_report_abs(wdata->extension.input, ABS_RX, rx - 0x20);
+> 	input_report_abs(wdata->extension.input, ABS_RY, ry - 0x20);
+> 	input_report_abs(wdata->extension.input, ABS_Z, rt);
+> 	input_report_abs(wdata->extension.input, ABS_RZ, lt);
+1232,1237c1232,1237
+< 	set_bit(ABS_HAT1X, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT1Y, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT2X, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT2Y, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT3X, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT3Y, wdata->extension.input->absbit);
+---
+> 	set_bit(ABS_X, wdata->extension.input->absbit);
+> 	set_bit(ABS_Y, wdata->extension.input->absbit);
+> 	set_bit(ABS_RX, wdata->extension.input->absbit);
+> 	set_bit(ABS_RY, wdata->extension.input->absbit);
+> 	set_bit(ABS_Z, wdata->extension.input->absbit);
+> 	set_bit(ABS_RZ, wdata->extension.input->absbit);
+1239c1239
+< 			     ABS_HAT1X, -30, 30, 1, 1);
+---
+> 			     ABS_X, -30, 30, 1, 1);
+1241c1241
+< 			     ABS_HAT1Y, -30, 30, 1, 1);
+---
+> 			     ABS_Y, -30, 30, 1, 1);
+1243c1243
+< 			     ABS_HAT2X, -30, 30, 1, 1);
+---
+> 			     ABS_RX, -30, 30, 1, 1);
+1245c1245
+< 			     ABS_HAT2Y, -30, 30, 1, 1);
+---
+> 			     ABS_RY, -30, 30, 1, 1);
+1247c1247
+< 			     ABS_HAT3X, -30, 30, 1, 1);
+---
+> 			     ABS_Z, -30, 30, 1, 1);
+1249c1249
+< 			     ABS_HAT3Y, -30, 30, 1, 1);
+---
+> 			     ABS_RZ, -30, 30, 1, 1);

--- a/package/sdl2/sdl2_input_as_retroarch_udev.patch
+++ b/package/sdl2/sdl2_input_as_retroarch_udev.patch
@@ -1,0 +1,54 @@
+diff --git a/src/joystick/linux/SDL_sysjoystick.c b/src/joystick/linux/SDL_sysjoystick.c
+index c37a22d..ab894b7 100644
+--- a/src/joystick/linux/SDL_sysjoystick.c
++++ b/src/joystick/linux/SDL_sysjoystick.c
+@@ -482,21 +482,12 @@ ConfigJoystick(SDL_Joystick * joystick, int fd)
+         (ioctl(fd, EVIOCGBIT(EV_REL, sizeof(relbit)), relbit) >= 0)) {
+ 
+         /* Get the number of buttons, axes, and other thingamajigs */
+-        for (i = BTN_JOYSTICK; i < KEY_MAX; ++i) {
++        for (i = 0; i < KEY_MAX; ++i) {
+             if (test_bit(i, keybit)) {
+ #ifdef DEBUG_INPUT_EVENTS
+                 printf("Joystick has button: 0x%x\n", i);
+ #endif
+-                joystick->hwdata->key_map[i - BTN_MISC] = joystick->nbuttons;
+-                ++joystick->nbuttons;
+-            }
+-        }
+-        for (i = BTN_MISC; i < BTN_JOYSTICK; ++i) {
+-            if (test_bit(i, keybit)) {
+-#ifdef DEBUG_INPUT_EVENTS
+-                printf("Joystick has button: 0x%x\n", i);
+-#endif
+-                joystick->hwdata->key_map[i - BTN_MISC] = joystick->nbuttons;
++                joystick->hwdata->key_map[i] = joystick->nbuttons;
+                 ++joystick->nbuttons;
+             }
+         }
+@@ -753,12 +744,9 @@ HandleInputEvents(SDL_Joystick * joystick)
+             code = events[i].code;
+             switch (events[i].type) {
+             case EV_KEY:
+-                if (code >= BTN_MISC) {
+-                    code -= BTN_MISC;
+                     SDL_PrivateJoystickButton(joystick,
+                                               joystick->hwdata->key_map[code],
+                                               events[i].value);
+-                }
+                 break;
+             case EV_ABS:
+                 if (code >= ABS_MISC) {
+diff --git a/src/joystick/linux/SDL_sysjoystick_c.h b/src/joystick/linux/SDL_sysjoystick_c.h
+index 16d16e2..9782c70 100644
+--- a/src/joystick/linux/SDL_sysjoystick_c.h
++++ b/src/joystick/linux/SDL_sysjoystick_c.h
+@@ -43,7 +43,7 @@ struct joystick_hwdata
+     } *balls;
+ 
+     /* Support for the Linux 2.4 unified input interface */
+-    Uint8 key_map[KEY_MAX - BTN_MISC];
++    Uint8 key_map[KEY_MAX];
+     Uint8 abs_map[ABS_MAX];
+     struct axis_correct
+     {

--- a/package/sdl2/sdl2_input_map_hat.patch
+++ b/package/sdl2/sdl2_input_map_hat.patch
@@ -1,0 +1,35 @@
+diff --git a/src/joystick/linux/SDL_sysjoystick.c b/src/joystick/linux/SDL_sysjoystick.c
+index c37a22d..4a30041 100644
+--- a/src/joystick/linux/SDL_sysjoystick.c
++++ b/src/joystick/linux/SDL_sysjoystick.c
+@@ -539,6 +539,8 @@ ConfigJoystick(SDL_Joystick * joystick, int fd)
+             }
+         }
+         for (i = ABS_HAT0X; i <= ABS_HAT3Y; i += 2) {
++   	    joystick->hwdata->hat_map[i]   = (joystick->nhats)*2;
++	    joystick->hwdata->hat_map[i+1] = (joystick->nhats)*2+1;
+             if (test_bit(i, absbit) || test_bit(i + 1, absbit)) {
+                 struct input_absinfo absinfo;
+ 
+@@ -774,8 +776,7 @@ HandleInputEvents(SDL_Joystick * joystick)
+                 case ABS_HAT2Y:
+                 case ABS_HAT3X:
+                 case ABS_HAT3Y:
+-                    code -= ABS_HAT0X;
+-                    HandleHat(joystick, code / 2, code % 2, events[i].value);
++                    HandleHat(joystick, joystick->hwdata->hat_map[code] / 2, joystick->hwdata->hat_map[code] % 2, events[i].value);
+                     break;
+                 default:
+                     events[i].value =
+diff --git a/src/joystick/linux/SDL_sysjoystick_c.h b/src/joystick/linux/SDL_sysjoystick_c.h
+index 16d16e2..d4f6f58 100644
+--- a/src/joystick/linux/SDL_sysjoystick_c.h
++++ b/src/joystick/linux/SDL_sysjoystick_c.h
+@@ -45,6 +45,7 @@ struct joystick_hwdata
+     /* Support for the Linux 2.4 unified input interface */
+     Uint8 key_map[KEY_MAX - BTN_MISC];
+     Uint8 abs_map[ABS_MAX];
++    Uint8 hat_map[ABS_MAX];
+     struct axis_correct
+     {
+         int used;


### PR DESCRIPTION
Summary of the 2 fixes :

1) make SDL2 considers any udev button
SDL2 ignores buttons which are not between BTN_MISC and KEY_MAX
RA_UDEV ignores buttons which are not between BTN_MISC and KEY_MAX or between KEY_UP and KEY_DOWN
2) make SDL2 assign buttons following the input.h file order as RA_UDEV does
an example joystick has 2 buttons : BTN_MISC and BTN_JOYSTICK

SDL2 will assign :
button 0 = BTN_JOYSTICK
button 1 = BTN_MISC

RA_UDEV will assign :
button 0 = BTN_MISC
button 1 = BTN_JOYSTICK

Buttons current behaviors :

SDL2:
between 0 and BTN_MISC-1 : ignored
between BTN_MISC and BTN_JOYSTICK-1 : second buttons group
between BTN_JOYSTICK and KEY_MAX : first buttons group

RA_UDEV:
between 0 and KEY_UP-1 : ignored
between KEY_UP and KEY_DOWN-1 : first buttons group
between KEY_DOWN and BTN_MISC-1 : ignored
between BTN_MISC and KEY_MAX : first buttons group

SDL2 updated to :
between 0 and KEY_MAX : first buttons group
no keys are ignored, so, potentially, we could update ra too if some poeple have buttons working in es but not in ra.
Risks :
1) SDL1 compatibiliy
theses modifications break compabitility between sdl1 and sdl2.
A joystick working with es but not working in ra could become not working on an other emulator based on sdl1.
2) Buttons reordering
A joystick configured in es could have to be reconfigured in case the buttons order has changed. However, if this occurs, it means that some buttons were already not working correctly in ra.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
