### PR TITLE
Option in recalbox.conf to enable/disable samba at startup

### DIFF
--- a/package/samba/S91smb
+++ b/package/samba/S91smb
@@ -15,6 +15,12 @@ mkdir -p /var/run/samba
 RETVAL=0
 
 start() {
+        if grep -q -E '^[ ]*system\.samba[ ]*=[ ]*0[ ]*$' /recalbox/share/system/recalbox.conf
+        then
+	  echo "SMB services: disabled"
+	  exit 0
+        fi
+
 	echo -n "Starting SMB services: "
 	smbd -D
 	RETVAL=$?


### PR DESCRIPTION
Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
