### PR TITLE
GCC 5.X fixups

### DIFF
--- a/package/localedef/localedef.mk
+++ b/package/localedef/localedef.mk
@@ -12,6 +12,10 @@ HOST_LOCALEDEF_CONF_OPTS += \
 	--prefix=/usr \
 	--with-glibc=./eglibc
 
+# Fix build on GCC5.1. Building host-localdef fails reporting multiple
+# definitions and undefined references
+HOST_LOCALEDEF_CONF_ENV = CFLAGS="$(HOST_CFLAGS) -fgnu89-inline"
+
 # The makefile does not implement an install target
 define HOST_LOCALEDEF_INSTALL_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/localedef $(HOST_DIR)/usr/bin/localedef

--- a/package/ncurses/0002-gcc-5.x-MKlib_gen.patch
+++ b/package/ncurses/0002-gcc-5.x-MKlib_gen.patch
@@ -1,33 +1,47 @@
-Fix GCC 5.x preprocessor failure
+from https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/sys-libs/ncurses/files/ncurses-5.9-gcc-5.patch?revision=1.1
+https://bugs.gentoo.org/545114
 
-Building ncurses 5.9 with GCC 5.x fails with a syntax error, caused by
-earlier preprocessing. This failure is more likely when building for
-host (e.g. host-ncurses) that recently updated to GCC 5.x.
+extracted from the upstream change (which had many unrelated commits in one)
 
-This patch is taken from the following link (more information is also
-available here):
-https://groups.google.com/forum/#!topic/sage-trac/U31shviuqzk
+From 97bb4678dc03e753290b39bbff30ba2825df9517 Mon Sep 17 00:00:00 2001
+From: "Thomas E. Dickey" <dickey@invisible-island.net>
+Date: Sun, 7 Dec 2014 03:10:09 +0000
+Subject: [PATCH] ncurses 5.9 - patch 20141206
 
-Signed-off-by: Doug Kehn <rdkehn@yahoo.com>
++ modify MKlib_gen.sh to work around change in development version of
+  gcc introduced here:
+	  https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
+	  https://gcc.gnu.org/ml/gcc-patches/2014-07/msg00236.html
+  (reports by Marcus Shawcroft, Maohui Lei).
 
-Index: b/ncurses/base/MKlib_gen.sh
-===================================================================
+diff --git a/ncurses/base/MKlib_gen.sh b/ncurses/base/MKlib_gen.sh
+index d8cc3c9..b91398c 100755
 --- a/ncurses/base/MKlib_gen.sh
 +++ b/ncurses/base/MKlib_gen.sh
-@@ -62,7 +62,15 @@ if test "${LC_MESSAGES+set}" = set; then
- if test "${LC_CTYPE+set}"    = set; then LC_CTYPE=C;    export LC_CTYPE;    fi
- if test "${LC_COLLATE+set}"  = set; then LC_COLLATE=C;  export LC_COLLATE;  fi
- 
--preprocessor="$1 -DNCURSES_INTERNALS -I../include"
-+# Work around "unexpected" output of GCC 5.1.0's cpp w.r.t. #line directives
-+# by simply suppressing them:
-+case `$1 -dumpversion 2>/dev/null` in
-+	5.[01].*)  # assume a "broken" one
-+		preprocessor="$1 -P -DNCURSES_INTERNALS -I../include"
-+		;;
-+	*)
-+		preprocessor="$1 -DNCURSES_INTERNALS -I../include"
-+esac
- AWK="$2"
- USE="$3"
- 
+@@ -474,11 +474,22 @@ sed -n -f $ED1 \
+	-e 's/gen_$//' \
+	-e 's/  / /g' >>$TMP
+
++cat >$ED1 <<EOF
++s/  / /g
++s/^ //
++s/ $//
++s/P_NCURSES_BOOL/NCURSES_BOOL/g
++EOF
++
++# A patch discussed here:
++#	https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
++# introduces spurious #line markers.  Work around that by ignoring the system's
++# attempt to define "bool" and using our own symbol here.
++sed -e 's/bool/P_NCURSES_BOOL/g' $TMP > $ED2
++cat $ED2 >$TMP
++
+ $preprocessor $TMP 2>/dev/null \
+-| sed \
+-	-e 's/  / /g' \
+-	-e 's/^ //' \
+-	-e 's/_Bool/NCURSES_BOOL/g' \
++| sed -f $ED1 \
+ | $AWK -f $AW2 \
+ | sed -f $ED3 \
+ | sed \


### PR DESCRIPTION
I've fixed 2 compilation problems that arose when I tried to build recalbox. 
Both of the patches are already in upstream or in a distro. Please test and apply.
