### PR TITLE
FBA LIBRETRO : unify rom path and systame name to fba_libretro

### DIFF
--- a/board/recalbox/share/system/.emulationstation/es_systems.cfg
+++ b/board/recalbox/share/system/.emulationstation/es_systems.cfg
@@ -174,7 +174,7 @@
     </system>
   <system>
         <fullname>FBA LIBRETRO</fullname>
-        <name>fbalibretro</name>
+        <name>fba_libretro</name>
         <path>/recalbox/share/roms/fba_libretro</path>
         <extension>.zip .ZIP .fba .FBA</extension>
         <command>python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.pyc %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM%</command>


### PR DESCRIPTION
Merge with https://github.com/recalbox/recalbox-configgen/pull/9
