### PR TITLE
Buildroot: Rewrite post-image scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 *._.DS_Store
 .config
 Thumbs.db
+authorized_keys

--- a/board/recalbox/copy-recalbox-archives.sh
+++ b/board/recalbox/copy-recalbox-archives.sh
@@ -1,26 +1,30 @@
-images="output/images"
+#!/bin/bash -e
 
-rm -rf $images/recalbox
-mkdir $images/recalbox
+# PWD = source dir
+# BASE_DIR = build dir
+# BUILD_DIR = base dir/build
+# HOST_DIR = base dir/host
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+
+RECALBOX_BINARIES_DIR="${BINARIES_DIR}/recalbox"
+RECALBOX_TARGET_DIR="${TARGET_DIR}/recalbox"
+
+if [ -d "${RECALBOX_BINARIES_DIR}" ]; then
+    rm -rf "${RECALBOX_BINARIES_DIR}"
+fi
+
+mkdir -p "${RECALBOX_BINARIES_DIR}"
 
 echo -e "\n----- Copying root archive -----\n"
-cp "$images/rootfs.tar.xz" "$images/recalbox/root.tar.xz"
-
+cp "${BINARIES_DIR}/rootfs.tar.xz" "${RECALBOX_BINARIES_DIR}/root.tar.xz"
 
 echo -e "\n----- Creating boot archive -----\n"
-tar -cvf "$images/recalbox/boot.tar" -C "$images/rpi-firmware/" "../zImage" `ls output/images/rpi-firmware/` ||
-        { echo "ERROR : unable to create boot.tar" && exit 1 ;}
-xz "$images/recalbox/boot.tar" || 
-        { echo "ERROR : unable to compress boot.tar" && exit 1 ;}
-
+cp -f "${BINARIES_DIR}/"*.dtb "${BINARIES_DIR}/rpi-firmware"
+"${HOST_DIR}/usr/bin/mkknlimg" "${BINARIES_DIR}/zImage" "${BINARIES_DIR}/rpi-firmware/zImage"
+tar -cvJf "${RECALBOX_BINARIES_DIR}/boot.tar.xz" -C "${BINARIES_DIR}/rpi-firmware" "." ||
+    { echo "ERROR : unable to create boot.tar.xz" && exit 1 ;}
 
 echo -e "\n----- Creating share archive -----\n"
-tar -cvf "$images/recalbox/share.tar" -C "board/recalbox/share/" `ls board/recalbox/share/` ||
-        { echo "ERROR : unable to create share.tar" && exit 1 ;}
-tar -rvf "$images/recalbox/share.tar" -C "output/target/recalbox/share/" `ls output/target/recalbox/share/` ||
-        { echo "ERROR : unable to create share.tar" && exit 1 ;}
-xz "$images/recalbox/share.tar" || 
-        { echo "ERROR : unable to compress share.tar" && exit 1 ;}
-
-
-
+tar --owner=root --group=root -cvJf "${RECALBOX_BINARIES_DIR}/share.tar.xz" -C "${PWD}/board/recalbox/share/" "." -C "${RECALBOX_TARGET_DIR}/share" "." ||
+    { echo "ERROR : unable to create share.tar.xz" && exit 1 ;}

--- a/board/recalbox/recalbox-patch-target.sh
+++ b/board/recalbox/recalbox-patch-target.sh
@@ -1,5 +1,23 @@
-#!/bin/sh
-target="output/target"
-sed -i "s|root:x:0:0:root:/root:/bin/sh|root:x:0:0:root:/recalbox/share/system:/bin/sh|g" "$target/etc/passwd"
-rm -rf "$target/etc/dropbear"
-ln -s "/recalbox/share/system/ssh" "$target/etc/dropbear" 
+#!/bin/bash -e
+
+# PWD = source dir
+# BASE_DIR = build dir
+# BUILD_DIR = base dir/build
+# HOST_DIR = base dir/host
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+
+RECALBOX_BINARIES_DIR="${BINARIES_DIR}/recalbox"
+RECALBOX_TARGET_DIR="${TARGET_DIR}/recalbox"
+RECALBOX_HOME_PWD="${PWD}/board/recalbox/share/system"
+RECALBOX_SSH_PWD="${RECALBOX_HOME_PWD}/.ssh"
+RECALBOX_SSH_AUTHORIZED_KEY_PWD="${RECALBOX_SSH_PWD}/authorized_keys"
+
+sed -i "s|root:x:0:0:root:/root:/bin/sh|root:x:0:0:root:/recalbox/share/system:/bin/sh|g" "${TARGET_DIR}/etc/passwd"
+rm -rf "${TARGET_DIR}/etc/dropbear"
+ln -s "/recalbox/share/system/ssh" "${TARGET_DIR}/etc/dropbear"
+chmod -R go-w "${RECALBOX_HOME_PWD}"
+mkdir -p "${RECALBOX_SSH_PWD}"
+chmod 0700 "${RECALBOX_SSH_PWD}"
+touch "${RECALBOX_SSH_AUTHORIZED_KEY_PWD}"
+chmod 0600 "${RECALBOX_SSH_AUTHORIZED_KEY_PWD}"


### PR DESCRIPTION
Allow to use them from in source tree and out of source tree.
Also shrink the code to make it more readable.
Add support for own ssh key and sftp-server.
Fix boot and share .tar.xz permissions.
