### PR TITLE
Update Moonlight.sh

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/scripts/moonlight/Moonlight.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/moonlight/Moonlight.sh
@@ -4,7 +4,7 @@
 #cd /recalbox/share/roms/moonlight/
 moonlight_dir=/recalbox/scripts/moonlight
 moonlight_romsdir=/recalbox/share/roms/moonlight
-moonlight_ip=192.168.111.35
+moonlight_ip=
 moonlight_screen="720"
 moonlight_fps="60fps"
 moonlight_mapping="$moonlight_dir/mapping.conf"


### PR DESCRIPTION
Avahi works, no need to specify any IP anymore
The script is still necessary for basic pairing + init = fetch games + scrape
Other options (map, app) shall be removed later
We shall discuss how to have a "SSH-less" basic configuration. Might ask the recalbox-manager guy
