### PR TITLE
kodi : replace the joystick detection by a better one with udev

### DIFF
--- a/package/kodi/0006-kodi-joystick-support.patch
+++ b/package/kodi/0006-kodi-joystick-support.patch
@@ -1,3 +1,16 @@
+From e6554b2527f6da41a02dcc03c55816a3c8ce42e7 Mon Sep 17 00:00:00 2001
+From: Nicolas Adenis-Lamarre <nicolas.adenis-lamarre@gmail.com>
+Date: Sat, 2 Jan 2016 23:31:00 +0100
+Subject: [PATCH] Kodi : support joystick detection via udev
+
+Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis-lamarre@gmail.com>
+---
+ configure.ac                           |  2 -
+ xbmc/input/SDLJoystick.cpp             |  7 +++
+ xbmc/input/linux/LinuxInputDevices.cpp | 82 ++++++++++++++++++++++++++++++++++
+ xbmc/input/linux/LinuxInputDevices.h   |  1 +
+ 4 files changed, 90 insertions(+), 2 deletions(-)
+
 diff --git a/configure.ac b/configure.ac
 index d5e76ee..a387bfd 100644
 --- a/configure.ac
@@ -19,7 +32,7 @@ index d5e76ee..a387bfd 100644
        [if test "$use_joystick" = "yes"; then
          AC_MSG_ERROR($sdl_joystick_not_found)
 diff --git a/xbmc/input/SDLJoystick.cpp b/xbmc/input/SDLJoystick.cpp
-index 5d910a3..b86d016 100644
+index e1a3e04..f93db12 100644
 --- a/xbmc/input/SDLJoystick.cpp
 +++ b/xbmc/input/SDLJoystick.cpp
 @@ -68,6 +68,13 @@ void CJoystick::Initialize()
@@ -37,30 +50,124 @@ index 5d910a3..b86d016 100644
  
  void CJoystick::AddJoystick(int joyIndex)
 diff --git a/xbmc/input/linux/LinuxInputDevices.cpp b/xbmc/input/linux/LinuxInputDevices.cpp
-index 32a3b46..da814b6 100644
+index 32a3b46..18734fb 100644
 --- a/xbmc/input/linux/LinuxInputDevices.cpp
 +++ b/xbmc/input/linux/LinuxInputDevices.cpp
-@@ -960,6 +960,23 @@ bool CLinuxInputDevices::CheckDevice(const char *device)
+@@ -42,6 +42,7 @@ typedef unsigned long kernel_ulong_t;
+ #endif
+ 
+ #include <linux/input.h>
++#include <libudev.h>
+ 
+ #ifndef EV_CNT
+ #define EV_CNT (EV_MAX+1)
+@@ -946,6 +947,60 @@ bool CLinuxInputDevice::IsUnplugged()
+   return m_bUnplugged;
+ }
+ 
++/*
++  this function is not powerfull because it reinitializes a new udev search each time
++  it would be nicer to call this only one time + one time at each hotplug
++  but it is already very fast, so, let's keep it simple and non intrusive
++*/
++bool CLinuxInputDevices::isUdevJoystick(const char* devpath) {
++  struct udev *udev;
++  struct udev_enumerate *enumerate;
++  struct udev_list_entry *devices, *dev_list_entry;
++  struct udev_device *dev;
++  const char *path;
++  const char *devfoundpath;
++  
++  udev = udev_new();
++  if (!udev) return false; // can't create udev
++
++  enumerate = udev_enumerate_new(udev);
++  if(enumerate == NULL) {
++    udev_unref(udev);
++    return false;
++  }
++
++  if(udev_enumerate_add_match_subsystem(enumerate, "input") == 0) {
++    if(udev_enumerate_add_match_property(enumerate, "ID_INPUT_JOYSTICK", "1") == 0) {
++      if(udev_enumerate_scan_devices(enumerate) >= 0) {
++	devices = udev_enumerate_get_list_entry(enumerate);
++
++	udev_list_entry_foreach(dev_list_entry, devices) {
++	  path = udev_list_entry_get_name(dev_list_entry);
++	  dev = udev_device_new_from_syspath(udev, path);
++	  if(dev != NULL) {
++	    devfoundpath = udev_device_get_devnode(dev);
++	    if(devfoundpath != NULL) {
++	      // found (finally !)
++	      //printf("=> %s\n", devfoundpath);
++	      if(strcmp(devfoundpath, devpath) == 0) {
++		udev_device_unref(dev);
++		udev_enumerate_unref(enumerate);
++		udev_unref(udev);
++		return true;
++	      }
++	    }
++	    udev_device_unref(dev);
++	  }
++	}
++      }
++    }
++  }
++
++  udev_enumerate_unref(enumerate);
++  udev_unref(udev);
++  return false;
++}
++
+ bool CLinuxInputDevices::CheckDevice(const char *device)
+ {
+   int fd;
+@@ -960,6 +1015,33 @@ bool CLinuxInputDevices::CheckDevice(const char *device)
    if (fd < 0)
      return false;
  
 +  // let others handle joysticks
-+  unsigned long evbit[NBITS(EV_MAX)] = { 0 };
-+  unsigned long keybit[NBITS(KEY_MAX)] = { 0 };
-+  unsigned long absbit[NBITS(ABS_MAX)] = { 0 };
 +
-+  if (!((ioctl(fd, EVIOCGBIT(0, sizeof(evbit)), evbit) < 0) ||
-+	(ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keybit)), keybit) < 0) ||
-+	(ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(absbit)), absbit) < 0))) {
-+    if (test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) &&
-+	test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit)) {
-+      CLog::Log(LOGNOTICE, "Avoiding joystick as normal input device - %s\n", device);
-+      close(fd);
-+      return false;
-+    }
-+  }
++  // THE OLD WAY
++  //unsigned long evbit[NBITS(EV_MAX)] = { 0 };
++  //unsigned long keybit[NBITS(KEY_MAX)] = { 0 };
++  //unsigned long absbit[NBITS(ABS_MAX)] = { 0 };
 +  //
++  //if (!((ioctl(fd, EVIOCGBIT(0, sizeof(evbit)), evbit) < 0) ||
++  //	(ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keybit)), keybit) < 0) ||
++  //	(ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(absbit)), absbit) < 0))) {
++  //  if (test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) &&
++  //	test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit)) {
++  //    CLog::Log(LOGNOTICE, "Found a joystick : use it as a joystick input device - %s\n", device);
++  //    close(fd);
++  //    return false;
++  //  }
++  //}
++
++  // THE UDEV WAY
++  if(isUdevJoystick(device)) {
++    CLog::Log(LOGNOTICE, "Found a joystick : use it as a joystick input device - %s\n", device);
++    close(fd);
++    return false;
++  } else {
++    CLog::Log(LOGNOTICE, "Found a non joystick : use it as standard kodi input device - %s\n", device);
++  }
 +
    if (ioctl(fd, EVIOCGRAB, 1) && errno != EINVAL)
    {
      close(fd);
+diff --git a/xbmc/input/linux/LinuxInputDevices.h b/xbmc/input/linux/LinuxInputDevices.h
+index cf1c5ce..f05673b 100644
+--- a/xbmc/input/linux/LinuxInputDevices.h
++++ b/xbmc/input/linux/LinuxInputDevices.h
+@@ -92,6 +92,7 @@ public:
+   size_t Size() { return m_devices.size(); }
+ private:
+   CCriticalSection m_devicesListLock;
++  bool isUdevJoystick(const char* devpath);
+   bool CheckDevice(const char *device);
+   std::vector<CLinuxInputDevice*> m_devices;
+   bool m_bReInitialize;
+-- 
+2.1.4
+


### PR DESCRIPTION
with udev ID_INPUT_JOYSTICK flag

this allow joyticks with no axis to work (wiimote for example)

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
