### PR TITLE
kodi : enable lirc in kodi 15

### DIFF
--- a/package/kodi/kodi.mk
+++ b/package/kodi/kodi.mk
@@ -195,7 +195,9 @@ else
 KODI_CONF_OPTS += --disable-libcec
 endif
 
-ifeq ($(BR2_PACKAGE_KODI_LIRC),n)
+ifeq ($(BR2_PACKAGE_KODI_LIRC),y)
+KODI_CONF_OPTS += --with-lirc-device=/var/run/lirc/lircd
+else
 KODI_CONF_OPTS += --disable-lirc
 endif
 

--- a/package/kodi/kodi.mk
+++ b/package/kodi/kodi.mk
@@ -195,9 +195,7 @@ else
 KODI_CONF_OPTS += --disable-libcec
 endif
 
-ifeq ($(BR2_PACKAGE_KODI_LIRC),y)
-KODI_CONF_OPTS += --enable-lirc
-else
+ifeq ($(BR2_PACKAGE_KODI_LIRC),n)
 KODI_CONF_OPTS += --disable-lirc
 endif
 


### PR DESCRIPTION
in kodi 15, lirc is enabled by default.
    --disable-lirc is used to disable lirc.
    Unfortunatly, --*-lirc does the same, including --enabled-lirc.
