### PR TITLE
storage: back to ext4 as default for internal

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -11,8 +11,8 @@
 
 SHARECONFFILE="/boot/recalbox.conf"
 INTERNALDEVICE="/dev/mmcblk0p3"
-INTERNALDEVICE_MOUNTOPT="noatime,iocharset=utf8,flush" # FAT32
-#INTERNALDEVICE_MOUNTOPT="noatime" # EXT4
+#INTERNALDEVICE_MOUNTOPT="noatime,iocharset=utf8,flush" # FAT32
+INTERNALDEVICE_MOUNTOPT="noatime" # EXT4
 MAXTRY=5
 NTRY=0
 
@@ -39,10 +39,10 @@ then
 	    parted -s /dev/mmcblk0 -m unit b mkpart primary "${PSTART}" 100%
 	    if test -e /dev/mmcblk0p3
 	    then
-		mkfs.vfat -F 32 -n SHARE /dev/mmcblk0p3 # if you replace this line, please change the INTERNALDEVICE_MOUNTOPT variable too in consequence
+		#mkfs.vfat -F 32 -n SHARE /dev/mmcblk0p3 # if you replace this line, please change the INTERNALDEVICE_MOUNTOPT variable too in consequence
 		#fsck.fat /dev/mmcblk0p3 -a
-		#mkfs.ext4 /dev/mmcblk0p3 -q -F -L SHARE
-		#e2fsck -f -p /dev/mmcblk0p3
+		mkfs.ext4 /dev/mmcblk0p3 -q -F -L SHARE
+		e2fsck -f -p /dev/mmcblk0p3
 	    fi
 	fi
     fi


### PR DESCRIPTION
internal partitions currently formatted in fat32 will continue to work after the upgrade,
but without the flush option,
and kodi will not be able to install some plugins (utf8 missing).
I advice to rebuild the .img while we will stay definitively in ext4 for the internal while it's really more robust
than
fat => no journal
ntfs => undocumented protocol ; not completly supported on linux (on journal features)

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
