### PR TITLE
wiimote: add missing kernel patch

### DIFF
--- a/board/recalbox/kernel_patches_4.1/linux-wiimote-abs-not-hat.patch
+++ b/board/recalbox/kernel_patches_4.1/linux-wiimote-abs-not-hat.patch
@@ -1,0 +1,54 @@
+--- a/drivers/hid/hid-wiimote-modules.c
++++ b/drivers/hid/hid-wiimote-modules.c
+1117,1122c1117,1122
+< 	input_report_abs(wdata->extension.input, ABS_HAT1X, lx - 0x20);
+< 	input_report_abs(wdata->extension.input, ABS_HAT1Y, ly - 0x20);
+< 	input_report_abs(wdata->extension.input, ABS_HAT2X, rx - 0x20);
+< 	input_report_abs(wdata->extension.input, ABS_HAT2Y, ry - 0x20);
+< 	input_report_abs(wdata->extension.input, ABS_HAT3X, rt);
+< 	input_report_abs(wdata->extension.input, ABS_HAT3Y, lt);
+---
+> 	input_report_abs(wdata->extension.input, ABS_X, lx - 0x20);
+> 	input_report_abs(wdata->extension.input, ABS_Y, ly - 0x20);
+> 	input_report_abs(wdata->extension.input, ABS_RX, rx - 0x20);
+> 	input_report_abs(wdata->extension.input, ABS_RY, ry - 0x20);
+> 	input_report_abs(wdata->extension.input, ABS_Z, rt);
+> 	input_report_abs(wdata->extension.input, ABS_RZ, lt);
+1232,1237c1232,1237
+< 	set_bit(ABS_HAT1X, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT1Y, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT2X, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT2Y, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT3X, wdata->extension.input->absbit);
+< 	set_bit(ABS_HAT3Y, wdata->extension.input->absbit);
+---
+> 	set_bit(ABS_X, wdata->extension.input->absbit);
+> 	set_bit(ABS_Y, wdata->extension.input->absbit);
+> 	set_bit(ABS_RX, wdata->extension.input->absbit);
+> 	set_bit(ABS_RY, wdata->extension.input->absbit);
+> 	set_bit(ABS_Z, wdata->extension.input->absbit);
+> 	set_bit(ABS_RZ, wdata->extension.input->absbit);
+1239c1239
+< 			     ABS_HAT1X, -30, 30, 1, 1);
+---
+> 			     ABS_X, -30, 30, 1, 1);
+1241c1241
+< 			     ABS_HAT1Y, -30, 30, 1, 1);
+---
+> 			     ABS_Y, -30, 30, 1, 1);
+1243c1243
+< 			     ABS_HAT2X, -30, 30, 1, 1);
+---
+> 			     ABS_RX, -30, 30, 1, 1);
+1245c1245
+< 			     ABS_HAT2Y, -30, 30, 1, 1);
+---
+> 			     ABS_RY, -30, 30, 1, 1);
+1247c1247
+< 			     ABS_HAT3X, -30, 30, 1, 1);
+---
+> 			     ABS_Z, -30, 30, 1, 1);
+1249c1249
+< 			     ABS_HAT3Y, -30, 30, 1, 1);
+---
+> 			     ABS_RZ, -30, 30, 1, 1);


### PR DESCRIPTION
Please note that i applied the patch manually while patches in
board/recalbox/kernel_patches_4.1
seem not to be applied

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
