### PR TITLE
mount : only 1 script to mount to control all mounting options

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -11,8 +11,7 @@
 
 SHARECONFFILE="/boot/recalbox.conf"
 INTERNALDEVICE="/dev/mmcblk0p3"
-#INTERNALDEVICE_MOUNTOPT="noatime,iocharset=utf8,flush" # FAT32
-INTERNALDEVICE_MOUNTOPT="noatime" # EXT4
+INTERNALDEVICETYPE="ext4" # faster than waiting udev to initialize to get the type
 MAXTRY=5
 NTRY=0
 
@@ -39,7 +38,7 @@ then
 	    parted -s /dev/mmcblk0 -m unit b mkpart primary "${PSTART}" 100%
 	    if test -e /dev/mmcblk0p3
 	    then
-		#mkfs.vfat -F 32 -n SHARE /dev/mmcblk0p3 # if you replace this line, please change the INTERNALDEVICE_MOUNTOPT variable too in consequence
+		#mkfs.vfat -F 32 -n SHARE /dev/mmcblk0p3 # if you replace this line, please change the INTERNALDEVICETYPE variable too in consequence
 		#fsck.fat /dev/mmcblk0p3 -a
 		mkfs.ext4 /dev/mmcblk0p3 -q -F -L SHARE
 		e2fsck -f -p /dev/mmcblk0p3
@@ -49,77 +48,21 @@ then
 fi
 #####
 
-# what's a hell to mount an ntfs device...
-mountNTFS() {
-    DEVICE=$1
-    RECALBOXFULLFS=$2
-    TESTFILE="${RECALBOXFULLFS}/recalbox.fsrw.test"
-    
-    if ! mount.ntfs-3g $*
-    then
-	return 1
-    fi
-
-    # check if the fs is rw because in some case, even if asked rw, fs will be mount in ro because of ntfs errors
-    if touch "${TESTFILE}"
-    then
-	rm "${TESTFILE}"
-	return 0
-    fi
-
-    # try to fix. It doesn't work in 100% of the case : in the worst case, you've to plug on a windows environement and run an fsck
-    if ! umount "${RECALBOXFULLFS}"
-    then
-	return 1
-    fi
-    ntfsfix -d "${DEVICE}"
-
-    # new try after ntfsfix
-    if ! mount.ntfs-3g $*
-    then
-	return 1
-    fi
-    
-    # check if the fs is rw because in some case, even if asked rw, fs will be mount in ro because of ntfs errors
-    if touch "${TESTFILE}"
-    then
-	rm "${TESTFILE}"
-	return 0
-    fi
-
-    # ask a fallback !
-    umount "${RECALBOXFULLFS}"
-    return 1
-}
-
 mountDeviceOrFallback() {
     DEVICE=$1
     TDEVICE=$2
     RECALBOXFULLFS="/var/recalboxfs"
     FALLBACK=1
 
-    if test "${TDEVICE}" = "ntfs"
-    then
-	FSMOUNTCMD=mountNTFS
-    else
-	FSMOUNTCMD=mount
-    fi
-
-    FSMOUNTOPT="noatime"
-    if test "${TDEVICE}" = "vfat"
-    then
-	FSMOUNTOPT="${FSMOUNTOPT},iocharset=utf8,flush"
-    fi
-    
     if test -n "${DEVICE}"
     then
 	if mkdir -p "${RECALBOXFULLFS}"
 	then
-	    if "${FSMOUNTCMD}" "${DEVICE}" "${RECALBOXFULLFS}" -o "${FSMOUNTOPT}"
+	    if /recalbox/scripts/recalbox-mount.sh "${TDEVICE}" 1 "${DEVICE}" "${RECALBOXFULLFS}"
 	    then
 		if mkdir -p "${RECALBOXFULLFS}/recalbox"
 		then
-		    if mount "${RECALBOXFULLFS}/recalbox" "/recalbox/share" -o "${FSMOUNTOPT}"
+		    if mount "${RECALBOXFULLFS}/recalbox" "/recalbox/share" -o "noatime"
 		    then
 			FALLBACK=0
 		    fi
@@ -130,7 +73,7 @@ mountDeviceOrFallback() {
 
     if test "${FALLBACK}" = 1
     then
-	if ! mount "${INTERNALDEVICE}" /recalbox/share -o "${INTERNALDEVICE_MOUNTOPT}"
+	if ! /recalbox/scripts/recalbox-mount.sh "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /recalbox/share
 	then
 	    mount -t tmpfs -o size=128M tmpfs /recalbox/share
 	fi
@@ -244,7 +187,7 @@ case "${MODE}" in
 	mount -t tmpfs -o size=128M tmpfs /recalbox/share
 	;;
     "INTERNAL"|*)
-	if ! mount "${INTERNALDEVICE}" /recalbox/share -o "${INTERNALDEVICE_MOUNTOPT}"
+	if ! /recalbox/scripts/recalbox-mount.sh "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /recalbox/share
 	then
 	    # fallback
 	    # the internal partition is no more required in fact

--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-mount.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-mount.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# rbmount [FSTYPE] [RWREQUIRED] [MOUNTDEVICE] [MOUNTPOINT]
+
+print_usage() {
+    echo "${0} [FSTYPE] [RWREQUIRED] [MOUNTDEVICE] [MOUNTPOINT]" >&2
+}
+
+if test $# -ne 4
+then
+    print_usage "${0}"
+    exit 1
+fi
+
+FSTYPE="$1"
+RWREQUIRED="$2"
+MOUNTDEVICE="$3"
+MOUNTPOINT="$4"
+FSMOUNTOPT="noatime"
+TESTFILE="${MOUNTPOINT}/recalbox.fsrw.test"
+
+# for non vfat and ntfs systems, it's easy
+if test "${FSTYPE}" != "vfat" -a "${FSTYPE}" != "ntfs"
+then
+    if mount "${MOUNTDEVICE}" "${MOUNTPOINT}" -o "${FSMOUNTOPT}"
+    then
+	exit 0
+    fi
+    exit 1
+fi
+
+# vfat and ntfs
+
+# change options
+case "${FSTYPE}" in
+    "vfat")
+	FSMOUNTOPT="${FSMOUNTOPT},iocharset=utf8,flush"
+	;;
+esac
+
+# try to mount
+case "${FSTYPE}" in
+    "vfat")
+	if ! mount "${MOUNTDEVICE}" "${MOUNTPOINT}" -o "${FSMOUNTOPT}"
+	    then
+	    exit 1
+	fi
+	;;
+    "ntfs")
+	if ! mount.ntfs-3g "${MOUNTDEVICE}" "${MOUNTPOINT}" -o "${FSMOUNTOPT}"
+	    then
+	    exit 1
+	fi
+	;;
+esac
+
+# for vfat, we don't continue if an fsck is required because it takes time
+# for ntfs, it's fast when it works
+if test "${RWREQUIRED}" != 1 -a "${FSTYPE}" = "vfat"
+then
+    exit 0 # success even if it's readonly
+fi
+
+# check if the fs is rw because in some case, even if asked rw, fs will be mount in ro because of ntfs errors
+if touch "${TESTFILE}"
+then
+    rm "${TESTFILE}"
+    exit 0 # that ok ;-)
+fi
+
+# try to fix. It doesn't work in 100% of the case : in the worst case, you've to plug on a windows environement and run an fsck
+if ! umount "${MOUNTPOINT}"
+then
+    exit 1
+fi
+
+# fix
+case "${FSTYPE}" in
+    "vfat")
+	fsck.vfat -a "${MOUNTDEVICE}" > "/dev/tty0" # write it on the terminal while it can take time
+	;;
+    "ntfs")
+	ntfsfix -d "${MOUNTDEVICE}"
+	;;
+esac
+
+# new try to mount
+case "${FSTYPE}" in
+    "vfat")
+	if ! mount "${MOUNTDEVICE}" "${MOUNTPOINT}" -o "${FSMOUNTOPT}"
+	    then
+	    exit 1
+	fi
+	;;
+    "ntfs")
+	if ! mount.ntfs-3g "${MOUNTDEVICE}" "${MOUNTPOINT}" -o "${FSMOUNTOPT}"
+	    then
+	    exit 1
+	fi
+	;;
+esac
+
+# new try to write
+if touch "${TESTFILE}"
+then
+    rm "${TESTFILE}"
+    exit 0 # that ok ;-)
+fi
+
+# if we really want rw
+if test "${RWREQUIRED}" = 1
+then
+    umount "${MOUNTPOINT}"
+    exit 1
+fi
+
+exit 0 # ok, but in read only

--- a/package/usbmount/0003-ntfs3g.patch
+++ b/package/usbmount/0003-ntfs3g.patch
@@ -2,17 +2,12 @@ diff --git a/usbmount b/usbmount
 index c09a865..7d89dbf 100755
 --- a/usbmount
 +++ b/usbmount
-@@ -123,7 +123,12 @@ if [ "$1" = add ]; then
+@@ -123,7 +123,7 @@ if [ "$1" = add ]; then
  
  		# Mount the filesystem.
  		log info "executing command: mount -t$fstype ${options:+-o$options} $DEVNAME $mountpoint"
 -		mount "-t$fstype" "${options:+-o$options}" "$DEVNAME" "$mountpoint"
-+		if test "$fstype" = "ntfs"
-+		then
-+		    mount.ntfs-3g "${options:+-o$options}" "$DEVNAME" "$mountpoint"
-+		else
-+		    mount "-t$fstype" "${options:+-o$options}" "$DEVNAME" "$mountpoint"
-+		fi
++		/recalbox/scripts/recalbox-mount.sh "$fstype" 0 "${DEVNAME}" "${mountpoint}"
  
  		# Determine vendor and model.
  		vendor=


### PR DESCRIPTION
1) only one place to mount for : S11share (mount share), usbmount and the future recalbox-sync
2) on ntfs : check to write a file, or run ntfsfix
3) on vfat : run fsck except for usbmount via a script option if writing a file fails

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
