### PR TITLE
bumped libretro-pcsx to the last commit

### DIFF
--- a/package/libretro-pcsx/libretro-pcsx.mk
+++ b/package/libretro-pcsx/libretro-pcsx.mk
@@ -3,7 +3,7 @@
 # PCSXREARMED
 #
 ################################################################################
-LIBRETRO_PCSX_VERSION = 0c840ff34defe22147f497c33e0ebad9386fada6 
+LIBRETRO_PCSX_VERSION = bb22137d8a5b660777896b1c470d5fc906201b37 
 LIBRETRO_PCSX_SITE = $(call github,libretro,pcsx_rearmed,$(LIBRETRO_PCSX_VERSION))
 
 define LIBRETRO_PCSX_BUILD_CMDS


### PR DESCRIPTION
Dynarec is no more used by this core. So the psx games was running at about 20fps.
