### PR TITLE
smb.conf : remove System data

### DIFF
--- a/board/recalbox/fsoverlay/etc/samba/smb.conf
+++ b/board/recalbox/fsoverlay/etc/samba/smb.conf
@@ -339,12 +339,3 @@ guest ok = yes
 create mask = 0644
 directory mask = 0755
 force user = root
-
-[System data]
-comment = Recalbox system data
-path = /recalbox/share_init
-writeable = no
-guest ok = yes
-create mask = 0444
-directory mask = 0555
-force user = root


### PR DESCRIPTION
Users are quite confused between "System ata" and "User data"
