### PR TITLE
Noobs adaptation + new update urls

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -11,6 +11,7 @@
 
 SHARECONFFILE="/boot/recalbox.conf"
 INTERNALDEVICE=`cat /boot/config.txt | grep "internal=" | head -n1 | cut -d'=' -f2`
+[[ "$?" -ne "0" || "$INTERNALDEVICE" == "" ]] && INTERNALDEVICE=/dev/mmcblk0p3
 INTERNALDEVICETYPE="ext4" # faster than waiting udev to initialize to get the type
 MAXTRY=5
 NTRY=0

--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -10,8 +10,11 @@
 ###
 
 SHARECONFFILE="/boot/recalbox.conf"
-INTERNALDEVICE=`cat /boot/config.txt | grep "internal=" | head -n1 | cut -d'=' -f2`
+INTERNALDEVICE=`cat ${SHARECONFFILE} | grep "internal=" | head -n1 | cut -d'=' -f2`
 [[ "$?" -ne "0" || "$INTERNALDEVICE" == "" ]] && INTERNALDEVICE=/dev/mmcblk0p3
+SHAREDEVICE=`cat ${SHARECONFFILE} | grep "sharedevice=" | head -n1 | cut -d'=' -f2`
+[[ "$?" -ne "0" || "$SHAREDEVICE" == "" ]] && SHAREDEVICE=INTERNAL
+
 INTERNALDEVICETYPE="ext4" # faster than waiting udev to initialize to get the type
 MAXTRY=5
 NTRY=0
@@ -157,7 +160,7 @@ do_upgrade() {
     return 0
 }
 
-RMODE=$(cat "${SHARECONFFILE}") # it can fails, it will go in fallback
+RMODE="$SHAREDEVICE" 
 
 if echo "${RMODE}" | grep -qE '^DEV '
 then

--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -126,7 +126,9 @@ do_upgrade() {
 	if (cd /boot && \
 	    cp cmdline.txt cmdline.txt.upgrade && \
 	    cp config.txt config.txt.upgrade && \
+	    cp recalbox-boot.conf recalbox-boot.conf.upgrade && \
 	    xz -dc < "${BOOTTAR}" | tar xvf - >> /tmp/upgrade.files && \
+	    mv recalbox-boot.conf.upgrade recalbox-boot.conf && \
 	    mv config.txt.upgrade config.txt && \
 	    mv cmdline.txt.upgrade cmdline.txt )
 	then

--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -10,7 +10,7 @@
 ###
 
 SHARECONFFILE="/boot/recalbox.conf"
-INTERNALDEVICE="/dev/mmcblk0p3"
+INTERNALDEVICE=`cat /boot/config.txt | grep "internal=" | head -n1 | cut -d'=' -f2`
 INTERNALDEVICETYPE="ext4" # faster than waiting udev to initialize to get the type
 MAXTRY=5
 NTRY=0

--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -119,7 +119,12 @@ do_upgrade() {
     echo "Upgrading /boot"
     if mount -o remount,rw /boot
     then
-	if (cd /boot && cp config.txt config.txt.upgrade && xz -dc < "${BOOTTAR}" | tar xvf - >> /tmp/upgrade.files && mv config.txt.upgrade config.txt)
+	if (cd /boot && \
+	    cp cmdline.txt cmdline.txt.upgrade && \
+	    cp config.txt config.txt.upgrade && \
+	    xz -dc < "${BOOTTAR}" | tar xvf - >> /tmp/upgrade.files && \
+	    mv config.txt.upgrade config.txt && \
+	    mv cmdline.txt.upgrade cmdline.txt )
 	then
 	    EXIT_CODE=0
 	fi
@@ -135,7 +140,10 @@ do_upgrade() {
     echo "Upgrading /"
     if mount -o remount,rw /
     then
-	if (cd / && xz -dc < "${ROOTTAR}" | tar xvf - >> /tmp/upgrade.files)
+	if (cd / && \
+	    cp ./etc/fstab ./etc/fstab.upgrade && \
+	    xz -dc < "${ROOTTAR}" | tar xvf - >> /tmp/upgrade.files && \
+	    mv ./etc/fstab.upgrade ./etc/fstab)
 	then
 	    EXIT_CODE=0
 	fi

--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -9,7 +9,7 @@
 # DEV [FSUUID] => a device having the FSUID uuid
 ###
 
-SHARECONFFILE="/boot/recalbox.conf"
+SHARECONFFILE="/boot/recalbox-boot.conf"
 INTERNALDEVICE=`cat ${SHARECONFFILE} | grep "internal=" | head -n1 | cut -d'=' -f2`
 [[ "$?" -ne "0" || "$INTERNALDEVICE" == "" ]] && INTERNALDEVICE=/dev/mmcblk0p3
 SHAREDEVICE=`cat ${SHARECONFFILE} | grep "sharedevice=" | head -n1 | cut -d'=' -f2`

--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -26,7 +26,7 @@ NB_FILES_TARGET=45000
 #
 # we don't remove data ;  only create a new partition if p3 is missing, and some free space is available only at the end of the disk
 #
-if ! test -e /dev/mmcblk0p3
+if ! test -e "${INTERNALDEVICE}"
 then
     # but the system partition exists
     if test -e /dev/mmcblk0p2
@@ -36,12 +36,12 @@ then
 	if test -n "${PSTART}"
 	then
 	    parted -s /dev/mmcblk0 -m unit b mkpart primary "${PSTART}" 100%
-	    if test -e /dev/mmcblk0p3
+	    if test -e "${INTERNALDEVICE}"
 	    then
 		#mkfs.vfat -F 32 -n SHARE /dev/mmcblk0p3 # if you replace this line, please change the INTERNALDEVICETYPE variable too in consequence
 		#fsck.fat /dev/mmcblk0p3 -a
-		mkfs.ext4 /dev/mmcblk0p3 -q -F -L SHARE
-		e2fsck -f -p /dev/mmcblk0p3
+		mkfs.ext4 "${INTERNALDEVICE}" -q -F -L SHARE
+		e2fsck -f -p "${INTERNALDEVICE}"
 	    fi
 	fi
     fi

--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
@@ -405,11 +405,15 @@ if [[ "$command" == "hiddpair" ]]; then
         exit $connected
 fi
 
+storageFile="/boot/recalbox.conf"
+
 if [[ "$command" == "storage" ]]; then
     if [[ "$mode" == "current" ]]; then
-	if test -e /boot/recalbox.conf
+	if test -e $storageFile
 	then
-	    cat /boot/recalbox.conf
+            SHAREDEVICE=`cat ${storageFile} | grep "sharedevice=" | head -n1 | cut -d'=' -f2`
+            [[ "$?" -ne "0" || "$SHAREDEVICE" == "" ]] && SHAREDEVICE=INTERNAL
+	    echo "$SHAREDEVICE"
 	else
 	    echo "INTERNAL"
 	fi
@@ -427,10 +431,18 @@ if [[ "$command" == "storage" ]]; then
     if [[ "$mode" == "INTERNAL" || "$mode" == "ANYEXTERNAL" || "$mode" == "RAM" || "$mode" == "DEV" ]]; then
 	preBootConfig
 	if [[ "$mode" == "INTERNAL" || "$mode" == "ANYEXTERNAL" || "$mode" == "RAM" ]]; then
-	    echo "$mode" > /boot/recalbox.conf
+            if [ `grep sharedevice $storageFile` ]; then
+               sed -i "s|sharedevice=.*|sharedevice=$mode|g" $storageFile
+            else
+               echo "sharedevice=$mode" >> $storageFile
+            fi
 	fi
 	if [[ "$mode" == "DEV" ]]; then
-            echo "$mode $extra1"  > /boot/recalbox.conf 
+            if [ `grep sharedevice $storageFile` ]; then
+               sed -i "s|sharedevice=.*|sharedevice=$mode $extra1|g" $storageFile
+            else
+               echo "sharedevice=$mode $extra1" >> $storageFile
+            fi
 	fi
 	postBootConfig
 	exit 0

--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
@@ -11,6 +11,8 @@ extra1="$3"
 extra2="$4"
 version=`cat /recalbox/recalbox.arch`
 
+recalboxupdateurl="http://archive.recalbox.com/4"
+
 preBootConfig() {
     mount -o remount,rw /boot
 }
@@ -261,9 +263,8 @@ if [ "$command" == "module" ];then
 	exit 0
 fi
 
-
 if [ "$command" == "canupdate" ];then
-	available=`wget -qO- http://archive2.recalbox.com/4.0.0/last/$version/recalbox.version`
+	available=`wget -qO- ${recalboxupdateurl}/$version/last/recalbox.version`
 	if [[ "$?" != "0" ]];then
 		exit 2
 	fi

--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
@@ -405,7 +405,7 @@ if [[ "$command" == "hiddpair" ]]; then
         exit $connected
 fi
 
-storageFile="/boot/recalbox.conf"
+storageFile="/boot/recalbox-boot.conf"
 
 if [[ "$command" == "storage" ]]; then
     if [[ "$mode" == "current" ]]; then

--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-upgrade.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-upgrade.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
 version=$(cat /recalbox/recalbox.arch)
+recalboxupdateurl="http://archive.recalbox.com/4"
 
 if ! mkdir -p /recalbox/share/system/upgrade
 then
     exit 1
 fi
 
-if ! wget "http://archive2.recalbox.com/4.0.0/last/${version}/boot.tar.xz" -O /recalbox/share/system/upgrade/boot.tar.xz.part
+if ! wget "${recalboxupdateurl}/${version}/last/boot.tar.xz" -O /recalbox/share/system/upgrade/boot.tar.xz.part
 then
     exit 1
 fi
 
-if ! wget "http://archive2.recalbox.com/4.0.0/last/${version}/root.tar.xz" -O /recalbox/share/system/upgrade/root.tar.xz.part
+if ! wget "${recalboxupdateurl}/${version}/last/root.tar.xz" -O /recalbox/share/system/upgrade/root.tar.xz.part
 then
     rm "/recalbox/share/system/upgrade/boot.tar.xz.part"
     exit 1

--- a/package/recalbox-system/recalbox-boot.conf
+++ b/package/recalbox-system/recalbox-boot.conf
@@ -1,0 +1,2 @@
+internal=/dev/mmcblk0p3
+sharedevice=INTERNAL

--- a/package/recalbox-system/recalbox-system.mk
+++ b/package/recalbox-system/recalbox-system.mk
@@ -22,6 +22,9 @@ define RECALBOX_SYSTEM_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/recalbox/share_init/system
 	cp package/recalbox-system/$(RECALBOX_SYSTEM_RECALBOX_CONF)/recalbox.conf $(TARGET_DIR)/recalbox/share_init/system
 	cp package/recalbox-system/$(RECALBOX_SYSTEM_RECALBOX_CONF)/recalbox.conf $(TARGET_DIR)/recalbox/share_init/system/recalbox.conf.template
+	# recalbox-boot.conf
+        $(INSTALL) -D -m 0644 package/recalbox-system/recalbox-boot.conf $(BINARIES_DIR)/rpi-firmware/recalbox-boot.conf
+
 endef
 
 $(eval $(generic-package))

--- a/package/recalbox-system/recalbox-system.mk
+++ b/package/recalbox-system/recalbox-system.mk
@@ -16,14 +16,6 @@ else
 	RECALBOX_SYSTEM_RECALBOX_CONF=rpi1
 endif
 
-ifeq ($(RECALBOX_RELEASE),FINAL)
-	ifeq ($(BR2_cortex_a7),y)
-		RECALBOX_SYSTEM_RPI_VERSION=rpi2-stable
-	else
-		RECALBOX_SYSTEM_RPI_VERSION=rpi1-stable
-	endif
-endif
-
 define RECALBOX_SYSTEM_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/recalbox/
 	echo -n "$(RECALBOX_SYSTEM_RPI_VERSION)" > $(TARGET_DIR)/recalbox/recalbox.arch

--- a/package/rpi-firmware/config.txt
+++ b/package/rpi-firmware/config.txt
@@ -35,3 +35,5 @@ gpu_mem_1024=512
 avoid_safe_mode=1
 
 kernel=zImage
+
+internal=/dev/mmcblk0p3

--- a/package/rpi-firmware/config.txt
+++ b/package/rpi-firmware/config.txt
@@ -35,5 +35,3 @@ gpu_mem_1024=512
 avoid_safe_mode=1
 
 kernel=zImage
-
-internal=/dev/mmcblk0p3


### PR DESCRIPTION
So 
- now we have the partition for internal storage directly in config.txt.
- it's by default /dev/mmcblk0p3 for img install and it's dynamically patched by the noobs installation : https://github.com/recalbox/recalbox-rescue/commit/50d28c85518a566d2dd84dda47c1ef97b3c0acc8
- the update url is now archive.recalbox.com/4/
- in the url, last link  is now in the differents arch directory, not in root dir
