### PR TITLE
OOB Remote control management.

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S12populateshare
+++ b/board/recalbox/fsoverlay/etc/init.d/S12populateshare
@@ -1,14 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 IN=/recalbox/share_init
 OUT=/recalbox/share
 
 # force the creation of some directories
-for DIR in cheats system system/.cache system/.emulationstation system/.emulationstation/themes system/bluetooth system/logs system/configs
+for DIR in cheats \
+           system/.cache \
+           system/.config/lirc \
+           system/.emulationstation/themes \
+           system/bluetooth \
+           system/configs \
+           system/logs
 do
     if test ! -e "$OUT""/""$DIR"
     then
-	mkdir "$OUT""/""$DIR"
+        mkdir -p "$OUT""/""$DIR"
     fi
 done
 
@@ -19,7 +25,12 @@ done
 # there are almost empty, it's just for the structure
 # the user can delete the directory, it will recreate the structure
 # the user can delete files, files will not be recreated
-for FILE in music bios extractions kodi saves screenshots system/.kodi system/.hatari system/.config system/configs/{fba,mupen64,retroarch,shadersets,moonlight} system/.emulationstation/{es_input.cfg,es_settings.cfg} system/recalbox.conf
+for FILE in music bios extractions kodi saves screenshots \
+            system/.config/lirc/lircd.conf \
+            system/.emulationstation/{es_input.cfg,es_settings.cfg} \
+            system/{.hatari,.kodi} \
+            system/configs/{fba,mupen64,retroarch,shadersets,moonlight} \
+            system/recalbox.conf
 do
     test ! -e "$OUT""/""$FILE" && cp -r "$IN""/""$FILE" "$OUT""/""$FILE"
 done

--- a/board/recalbox/fsoverlay/recalbox/share_init/system/.config/lirc/lircd.conf
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/.config/lirc/lircd.conf
@@ -1,4 +1,4 @@
 
 # THIS FILE MUST BE CONFIGURED TO MAP YOUR REMOTE
 # SEE https://github.com/digitalLumberjack/recalbox-os/wiki
-
+include "../../../../share_init/system/.config/lirc/lircd.conf.d/*.conf"

--- a/board/recalbox/fsoverlay/recalbox/share_init/system/.config/lirc/lircd.conf.d/mceusb.lircd.conf
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/.config/lirc/lircd.conf.d/mceusb.lircd.conf
@@ -1,0 +1,334 @@
+#
+# brand:                        HP
+# model no. of remote control:  TSGH-IR01
+# devices being controlled by this remote: HP Slimline S3100y
+#
+# RC-6 config file
+#
+# source: http://home.hccnet.nl/m.majoor/projects_remote_control.htm
+#         http://home.hccnet.nl/m.majoor/pronto.pdf
+#
+# used by: Philips
+#
+#########
+#
+# Philips Media Center Edition remote control
+# For use with the USB MCE ir receiver
+#
+# Dan Conti  dconti|acm.wwu.edu
+#
+# Updated with codes for MCE 2005 Remote additional buttons
+# *, #, Teletext, Red, Green, Yellow & Blue Buttons
+# Note: TV power button transmits no code until programmed.
+# Updated 12th September 2005
+# Graham Auld - mce|graham.auld.me.uk
+#
+# Radio, Print, RecTV are only available on the HP Media Center remote control
+#
+#
+# Updated with codes for MCE 2007 Remote additional buttons
+# Visualization, Aspect, SlideShow, Eject
+# Note:
+# Renamed some buttons: DVD->DVDMenu, More->MoreInfo, Star->Asterisk, Hash->Pound
+# Note:
+# Blue, Yellow, Green, Red, and Teletext buttons do not exist on the HP remote
+
+begin remote
+
+  name        mceusb
+  bits                 16
+  flags  RC6|CONST_LENGTH
+  eps                  30
+  aeps                100
+
+  header       2667   889
+  one           444   444
+  zero          444   444
+  pre_data_bits        21
+  pre_data        0x37FF0
+  gap              105000
+  toggle_bit           22
+  rc6_mask    0x100000000
+
+
+      begin codes
+
+#seen on HP Pavilion dv3t remote  --Tim Mann, 3 Nov 2009
+	Media         0x00007b7f
+          KEY_PLAYPAUSE            0x00007b91                #  Was: PlayPause
+
+
+#unused by HP remote
+          KEY_BLUE                 0x00007ba1                #  Was: Blue
+          KEY_YELLOW               0x00007ba2                #  Was: Yellow
+          KEY_GREEN                0x00007ba3                #  Was: Green
+          KEY_RED                  0x00007ba4                #  Was: Red
+          KEY_TEXT                 0x00007ba5                #  Was: Teletext
+
+#ba6 - bae unused
+        BA6           0x00007ba6
+        BA7           0x00007ba7
+        BA8           0x00007ba8
+        BA9           0x00007ba9
+        BAA           0x00007baa
+        BAB           0x00007bab
+        BAC           0x00007bac
+        BAD           0x00007bad
+        BAE           0x00007bae
+
+          KEY_RADIO                0x00007baf                #  Was: Radio
+        Print         0x00007bb1
+
+#bb2 - bb4 unused
+        BB2           0x00007bb2
+        BB3           0x00007bb3
+        BB4           0x00007bb4
+
+          KEY_VIDEO                0x00007bb5                #  Was: Videos
+          KEY_IMAGES               0x00007bb6                #  Was: Pictures
+          RecTV                    0x00007bb7                #  Was: RecTV
+          KEY_AUDIO                0x00007bb8                #  Was: Music
+          KEY_TV                   0x00007bb9                #  Was: TV
+
+#bba - bbf unused
+        BBA           0x00007bba
+        BBB           0x00007bbb
+        BBC           0x00007bbc
+        BBD           0x00007bbd
+        BBE           0x00007bbe
+        BBF           0x00007bbf
+#bc1 - bca unused
+        BC1           0x00007bc1
+        BC2           0x00007bc2
+        BC3           0x00007bc3
+        BC4           0x00007bc4
+        BC5           0x00007bc5
+        BC6           0x00007bc6
+        BC7           0x00007bc7
+        BC8           0x00007bc8
+        BC9           0x00007bc9
+        BCA           0x00007bca
+
+          KEY_EJECTCD              0x00007bcb                #  Was: Eject
+        SlideShow     0x00007bcc
+        Visualization 0x00007bcd
+
+#bce - bcf unused
+        BCE           0x00007bce
+        BCF           0x00007bcf
+#bd1 - bd7 unused
+        BD1           0x00007bd1
+        BD2           0x00007bd2
+        BD3           0x00007bd3
+        BD4           0x00007bd4
+        BD5           0x00007bd5
+        BD6           0x00007bd6
+        BD7           0x00007bd7
+
+        Aspect        0x00007bd8
+          KEY_EPG                  0x00007bd9                #  Was: Guide
+          LiveTV                   0x00007bda                #  Was: LiveTV
+          KEY_DVD                  0x00007bdb                #  Was: DVD
+#NoGap
+          KEY_BACK                 0x00007bdc                #  Was: Back
+          KEY_OK                   0x00007bdd                #  Was: OK
+          KEY_RIGHT                0x00007bde                #  Was: Right
+          KEY_LEFT                 0x00007bdf                #  Was: Left
+          KEY_DOWN                 0x00007be0                #  Was: Down
+          KEY_UP                   0x00007be1                #  Was: Up
+#NoGap
+          KEY_NUMERIC_STAR         0x00007be2                #  Was: Star
+          KEY_NUMERIC_POUND        0x00007be3                #  Was: Hash
+#NoGap
+          KEY_AGAIN                0x00007be4                #  Was: Replay
+          KEY_NEXT                 0x00007be5                #  Was: Skip
+          KEY_STOP                 0x00007be6                #  Was: Stop
+          KEY_PAUSE                0x00007be7                #  Was: Pause
+          KEY_RECORD               0x00007be8                #  Was: Record
+          KEY_PLAY                 0x00007be9                #  Was: Play
+          KEY_REWIND               0x00007bea                #  Was: Rewind
+          KEY_FORWARD              0x00007beb                #  Was: Forward
+#NoGap
+          KEY_CHANNELDOWN          0x00007bec                #  Was: ChanDown
+          KEY_CHANNELUP            0x00007bed                #  Was: ChanUp
+          KEY_VOLUMEDOWN           0x00007bee                #  Was: VolDown
+          KEY_VOLUMEUP             0x00007bef                #  Was: VolUp
+#NoGap
+        More          0x00007bf0
+          KEY_MUTE                 0x00007bf1                #  Was: Mute
+          KEY_HOME                 0x00007bf2                #  Was: Home
+          KEY_POWER                0x00007bf3                #  Was: Power
+#NoGap
+          KEY_ENTER                0x00007bf4                #  Was: Enter
+          KEY_CLEAR                0x00007bf5                #  Was: Clear
+#NoGap
+          KEY_9                    0x00007bf6                #  Was: Nine
+          KEY_8                    0x00007bf7                #  Was: Eight
+          KEY_7                    0x00007bf8                #  Was: Seven
+          KEY_6                    0x00007bf9                #  Was: Six
+          KEY_5                    0x00007bfa                #  Was: Five
+          KEY_4                    0x00007bfb                #  Was: Four
+          KEY_3                    0x00007bfc                #  Was: Three
+          KEY_2                    0x00007bfd                #  Was: Two
+          KEY_1                    0x00007bfe                #  Was: One
+          KEY_0                    0x00007bff                #  Was: Zero
+      end codes
+
+end remote
+#
+# this config file was automatically generated
+# using lirc-0.8.4a(default) on Mon Feb 23 23:55:04 2009
+#
+# contributed by
+#
+# brand:                       Hauppauge
+# model no. of remote control:
+# devices being controlled by this remote: PVR-150 Remote (MCE kit)
+# SMK dongle 0609:031d
+#
+
+begin remote
+
+  name  mceusb_hauppauge
+  bits           13
+  flags RC6|CONST_LENGTH
+  eps            30
+  aeps          100
+
+  header       2674   870
+  one           455   427
+  zero          455   427
+  pre_data_bits   24
+  pre_data       0x1BFF82
+  gap          106288
+  min_repeat      1
+  toggle_bit_mask 0x8000
+  rc6_mask    0x100000000
+
+      begin codes
+          KEY_TV                   0x1BB9                    #  Was: TV
+          KEY_AUDIO                0x1BB8                    #  Was: Music
+          KEY_IMAGES               0x1BB6                    #  Was: Pictures
+          KEY_VIDEO                0x1BB5                    #  Was: Videos
+          KEY_POWER                0x1BF3                    #  Was: Power
+          KEY_STOP                 0x1BE6                    #  Was: Stop
+          KEY_RECORD               0x1BE8                    #  Was: Record
+          KEY_PAUSE                0x1BE7                    #  Was: Pause
+          KEY_PLAY                 0x1BE9                    #  Was: Play
+          KEY_REWIND               0x1BEA                    #  Was: Rewind
+          Foward                   0x1BEB
+          KEY_AGAIN                0x1BE4                    #  Was: Replay
+          KEY_NEXT                 0x1BE5                    #  Was: Skip
+          KEY_BACK                 0x1BDC                    #  Was: Back
+          More                     0x1BF0
+          KEY_UP                   0x1BE1                    #  Was: Up
+          KEY_LEFT                 0x1BDF                    #  Was: Left
+          KEY_RIGHT                0x1BDE                    #  Was: Right
+          KEY_OK                   0x1BDD                    #  Was: OK
+          KEY_DOWN                 0x1BE0                    #  Was: Down
+          KEY_VOLUMEUP             0x1BEF                    #  Was: VolUp
+          KEY_VOLUMEDOWN           0x1BEE                    #  Was: VolDown
+          KEY_HOME                 0x1BF2                    #  Was: Home
+          KEY_CHANNELDOWN          0x1BED                    #  Was: ChanDown
+          KEY_CHANNELUP            0x1BEC                    #  Was: ChanUp
+          KEY_MUTE                 0x1BF1                    #  Was: Mute
+          RecTV                    0x1BB7                    #  Was: RecTV
+          KEY_EPG                  0x1BD9                    #  Was: Guide
+          LiveTV                   0x1BDA                    #  Was: LiveTV
+          KEY_DVD                  0x1BDB                    #  Was: DVD
+          KEY_1                    0x1BFE                    #  Was: One
+          KEY_2                    0x1BFD                    #  Was: Two
+          KEY_3                    0x1BFC                    #  Was: Three
+          KEY_4                    0x1BFB                    #  Was: Four
+          KEY_5                    0x1BFA                    #  Was: Five
+          KEY_6                    0x1BF9                    #  Was: Six
+          KEY_7                    0x1BF8                    #  Was: Seven
+          KEY_8                    0x1BF7                    #  Was: Eight
+          KEY_9                    0x1BF6                    #  Was: Nine
+          KEY_NUMERIC_STAR         0x1BE2                    #  Was: Star
+          KEY_0                    0x1BFF                    #  Was: Zero
+          KEY_NUMERIC_POUND        0x1BE3                    #  Was: Hash
+          KEY_CLEAR                0x1BF5                    #  Was: Clear
+          KEY_ENTER                0x1BF4                    #  Was: Enter
+      end codes
+
+end remote
+
+
+#
+# this config file was automatically generated
+# using lirc-0.8.4a(default) on Tue Mar 10 19:27:09 2009
+#
+# contributed by
+#
+# brand:  SIIG Vista MCE remote
+# model no. of remote control:
+# devices being controlled by this remote:
+#
+
+begin remote
+
+  name  vista_mce
+  bits           16
+  flags RC6
+  eps            30
+  aeps          100
+
+  header       2654   889
+  one           427   427
+  zero          427   427
+  pre_data_bits   21
+  pre_data       0x37FF0
+  gap          69850
+  toggle_bit_mask 0x8000
+  rc6_mask    0x100000000
+
+      begin codes
+          KEY_POWER                0xEBF3                    #  Was: Power
+          KEY_IMAGES               0x6BB6                    #  Was: Pictures
+          KEY_RADIO                0xEBAF                    #  Was: Radio
+          KEY_VIDEO                0x6BB5                    #  Was: Videos
+          KEY_AUDIO                0xEBB8                    #  Was: Music
+          KEY_RECORD               0x6BE8                    #  Was: Rec
+          KEY_PAUSE                0xEBE7                    #  Was: Pause
+          KEY_STOP                 0x6BE6                    #  Was: Stop
+          KEY_REWIND               0xEBE4                    #  Was: Skipback
+          KEY_PLAY                 0x6BE9                    #  Was: Play
+          KEY_FASTFORWARD          0xEBE5                    #  Was: Skipfwd
+          Rwd                      0x6BEA
+          KEY_FORWARD              0xEBEB                    #  Was: Fwd
+          Start                    0x6BF2                    #  Was: Start
+          KEY_BACK                 0xEBDC                    #  Was: Back
+          More                     0x6BF0
+          KEY_VOLUMEUP             0xEBEF                    #  Was: Volup
+          KEY_VOLUMEDOWN           0x6BEE                    #  Was: Voldown
+          KEY_CHANNELUP            0xEBED                    #  Was: Chup
+          KEY_CHANNELDOWN          0x6BEC                    #  Was: Chdown
+          KEY_UP                   0xEBE1                    #  Was: Up
+          KEY_DOWN                 0x6BE0                    #  Was: Down
+          KEY_LEFT                 0xEBDF                    #  Was: Left
+          KEY_RIGHT                0x6BDE                    #  Was: Right
+          KEY_MUTE                 0xEBF1                    #  Was: Mute
+          RecTV                    0x6BB7                    #  Was: Rectv
+          KEY_EPG                  0xEBD9                    #  Was: Guide
+          KEY_TV                   0x6BDA                    #  Was: Livetv
+          KEY_MENU                 0xEBDB                    #  Was: Dvdmenu
+          KEY_1                    0x6BFE                    #  Was: 1
+          KEY_2                    0xEBFD                    #  Was: 2
+          KEY_3                    0x6BFC                    #  Was: 3
+          KEY_4                    0xEBFB                    #  Was: 4
+          KEY_5                    0x6BFA                    #  Was: 5
+          KEY_6                    0xEBF9                    #  Was: 6
+          KEY_7                    0x6BF8                    #  Was: 7
+          KEY_8                    0xEBF7                    #  Was: 8
+          KEY_9                    0x6BF6                    #  Was: 9
+          KEY_NUMERIC_STAR         0xEBE2                    #  Was: \*
+          KEY_0                    0x6BFF                    #  Was: 0
+          KEY_NUMERIC_POUND        0xEBE3                    #  Was: #
+          KEY_CLEAR                0x6BF5                    #  Was: Clear
+          KEY_ENTER                0xEBF4                    #  Was: Enter
+      end codes
+
+end remote
+
+


### PR DESCRIPTION
- Standard remote control can work OOB with xbmc as soon as they are referenced in the system's Lircmap.xml located in /usr/share/kodi/system/ (https://github.com/xbmc/xbmc/blob/master/system/Lircmap.xml).
- Corresponding LIRC conf files can be found at : http://lirc-remotes.sourceforge.net/remotes-table.html
- Sample made and tested with the mceusb (Media Center Edition)
