### PR TITLE
xarcade2jstick : now starts keyboard encoders

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S26recalboxsystem
+++ b/board/recalbox/fsoverlay/etc/init.d/S26recalboxsystem
@@ -118,7 +118,18 @@ rb_xarcade2jstick() {
     settings_xarcade="`$systemsetting -command load -key controllers.xarcade.enabled`"
     if [[ "$settings_xarcade" == "1" ]];then
         recallog "starting xarcade2jstick"
-        start-stop-daemon --background --start --quiet --exec /usr/bin/xarcade2jstick
+        # First try : suppose a real X-Arcade is plugged
+        /usr/bin/xarcade2jstick -d
+        if [ $? -ne "0" ]
+        then
+            # the user must have a keyboard encoder then
+            recallog "xarcade2jstick : no official stick found, looking for keyboard encoder now ..."
+            for dev in /recalbox/share_init/system/configs/xarcade2jstick/*
+            do
+                dev=$(basename "$dev")
+                [ -h "/dev/input/by-id/$dev" ] && recallog "xarcade2jstick : Found $dev ! Starting xarcade2jstick ..." && /usr/bin/xarcade2jstick -d -e "/dev/input/by-id/$dev" && break
+            done
+        fi
     fi
 }
 


### PR DESCRIPTION
keyboard encoders should have there /dev/input/by-id name in /recalbox/share_init/system/configs/xarcade2jstick
At launch, S26recalboxsystem starts xarcade2jstick without any parameter, meaning it is looking for a genuine X-Gaming stick
If no X-Arcade stick is found, then proceed to keyboard encoders. File name must match between /dev/input/by-id and /recalbox/share_init/system/configs/xarcade2jstick to be recognised as a valid encoder
Handles only 1 encoder for now. Can be updated to handle any if needed
