### PR TITLE
kodi: remove double joystick init (was ok in 14, but not in 15)

### DIFF
--- a/package/kodi/0006-kodi-joystick-support.patch
+++ b/package/kodi/0006-kodi-joystick-support.patch
@@ -31,24 +31,6 @@ index d5e76ee..a387bfd 100644
         INCLUDES="$INCLUDES $SDL2_CFLAGS"; LIBS="$LIBS $SDL2_LIBS"; use_joystick="yes"],
        [if test "$use_joystick" = "yes"; then
          AC_MSG_ERROR($sdl_joystick_not_found)
-diff --git a/xbmc/input/SDLJoystick.cpp b/xbmc/input/SDLJoystick.cpp
-index e1a3e04..f93db12 100644
---- a/xbmc/input/SDLJoystick.cpp
-+++ b/xbmc/input/SDLJoystick.cpp
-@@ -68,6 +68,13 @@ void CJoystick::Initialize()
-   SetDeadzone(g_advancedSettings.m_controllerDeadzone);
- 
-   // joysticks will be loaded once SDL sees them
-+#ifdef HAS_SDL_JOYSTICK
-+#ifndef HAS_SDL
-+  for(int i=0; i<SDL_NumJoysticks(); i++) {
-+    AddJoystick(i);
-+  }
-+#endif
-+#endif
- }
- 
- void CJoystick::AddJoystick(int joyIndex)
 diff --git a/xbmc/input/linux/LinuxInputDevices.cpp b/xbmc/input/linux/LinuxInputDevices.cpp
 index 32a3b46..18734fb 100644
 --- a/xbmc/input/linux/LinuxInputDevices.cpp


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes : none

Changes :
- remove a double initialisation of joystick in kodi (this modification was required in kodi14 but create an unnecessary double init in kodi 15 / or perhaps the add/remove patch already does it)
- it fixes nothing

Related to (put here the others PR in other repositories)

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
