### PR TITLE
moonlight : bump to 2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 - New version of xboxdrv
 - Corrected 8bitdo mapping
+- Bumped to moonlight-embedded-2.1.4
 
 ## [3.3.0-beta16] - 2015-11-24
 - Corrected kodi start

--- a/package/moonlight-embedded/moonlight-embedded.mk
+++ b/package/moonlight-embedded/moonlight-embedded.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MOONLIGHT_EMBEDDED_VERSION = 2.1.3
+MOONLIGHT_EMBEDDED_VERSION = 2.1.4
 MOONLIGHT_EMBEDDED_SOURCE = moonlight-embedded-$(MOONLIGHT_EMBEDDED_VERSION).tar.xz
 MOONLIGHT_EMBEDDED_SITE = https://github.com/irtimmer/moonlight-embedded/releases/download/v$(MOONLIGHT_EMBEDDED_VERSION)
 MOONLIGHT_EMBEDDED_DEPENDENCIES = opus expat libevdev avahi alsa-lib udev libcurl libcec ffmpeg sdl2


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
- bump to 2.1.4, should work better with GFE 2.10

Related to (put here the others PR in other repositories)

Solves many problems of 2.1.3 : pairing problems, in-game video freeze
