### PR TITLE
recalbox-support.sh : add input devices info

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-support.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-support.sh
@@ -39,14 +39,16 @@ fi
 
 # SYSTEM
 DSYSTEM="$TMPDIR""/system"
-dmesg 	         > "$DSYSTEM""/dmesg.txt"
-lsmod 	         > "$DSYSTEM""/lsmod.txt"
-ps    	         > "$DSYSTEM""/ps.txt"
-df -h 	         > "$DSYSTEM""/df.txt"
-netstat -tuan    > "$DSYSTEM""/netstat.txt"
-lsusb -v         > "$DSYSTEM""/lsusb.txt" 2>/dev/null
-tvservice -m CEA > "$DSYSTEM""/tvservice-CEA.txt"
-tvservice -m DMT > "$DSYSTEM""/tvservice-DMT.txt"
+dmesg 	                    > "$DSYSTEM""/dmesg.txt"
+lsmod 	                    > "$DSYSTEM""/lsmod.txt"
+ps    	                    > "$DSYSTEM""/ps.txt"
+df -h 	                    > "$DSYSTEM""/df.txt"
+netstat -tuan               > "$DSYSTEM""/netstat.txt"
+lsusb -v                    > "$DSYSTEM""/lsusb.txt" 2>/dev/null
+tvservice -m CEA            > "$DSYSTEM""/tvservice-CEA.txt"
+tvservice -m DMT            > "$DSYSTEM""/tvservice-DMT.txt"
+cat /proc/bus/input/devices > "$DSYSTEM""/input-devices.txt"
+
 f_cp /recalbox/recalbox.version                               "$DSYSTEM"
 f_cp /recalbox/recalbox.arch                                  "$DSYSTEM"
 f_cp /boot/config.txt                                         "$DSYSTEM"


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes nothing

Changes :
- add a `cat /proc/bus/input/devices` for a better visibility of input devices

Related to (put here the others PR in other repositories) -> nothing
