### PR TITLE
fix retroachievement support on picodrive and fceumm libretro cores

### DIFF
--- a/package/libretro-fceumm/libretro-fceumm.mk
+++ b/package/libretro-fceumm/libretro-fceumm.mk
@@ -3,7 +3,7 @@
 # FCEUMM
 #
 ################################################################################
-LIBRETRO_FCEUMM_VERSION = c72c71005c798da1b38ea4bee4d932c17375ab4f
+LIBRETRO_FCEUMM_VERSION = 68f07514c69183b8f3280c86e1d5faca619b5f85
 LIBRETRO_FCEUMM_SITE = $(call github,libretro,libretro-fceumm,$(LIBRETRO_FCEUMM_VERSION))
 
 define LIBRETRO_FCEUMM_BUILD_CMDS

--- a/package/libretro-picodrive/libretro-picodrive.mk
+++ b/package/libretro-picodrive/libretro-picodrive.mk
@@ -3,7 +3,7 @@
 # libretro-picodrive
 #
 ################################################################################
-LIBRETRO_PICODRIVE_VERSION = 24a7ff72233aaf09dfdaa2f11c5c2bbcab236195
+LIBRETRO_PICODRIVE_VERSION = d277f0aae381c6fcd31a2247970a85be8551b0bd
 LIBRETRO_PICODRIVE_SITE = $(call github,libretro,picodrive,$(LIBRETRO_PICODRIVE_VERSION))
 LIBRETRO_PICODRIVE_DEPENDENCIES = libpng sdl
 


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
- bumped picodrive and fceumm libretro cores, should add retroachievements support
