### PR TITLE
Make sure custom.sh is executable

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S99custom
+++ b/board/recalbox/fsoverlay/etc/init.d/S99custom
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-test -e "/recalbox/share/system/custom.sh" && /recalbox/share/system/custom.sh
+test -e "/recalbox/share/system/custom.sh" && chmod +x /recalbox/share/system/custom.sh && /recalbox/share/system/custom.sh


### PR DESCRIPTION
If the user adds a custom.sh via SAMBA, it won't get the executable permission.
This fixes that and other cases where the user may forget to make it executable.
