### PR TITLE
kodi: don't shutdown the tv on exit

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/share_init/system/.kodi/peripheral_data/rpi_2708_1001.xml
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/.kodi/peripheral_data/rpi_2708_1001.xml
@@ -1,3 +1,0 @@
-<settings>
-    <setting id="standby_devices" value="231" />
-</settings>

--- a/board/recalbox/fsoverlay/recalbox/share_init/system/.kodi/userdata/peripheral_data/rpi_2708_1001.xml
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/.kodi/userdata/peripheral_data/rpi_2708_1001.xml
@@ -1,0 +1,23 @@
+<settings>
+    <setting id="activate_source" value="1" />
+    <setting id="cec_hdmi_port" value="1" />
+    <setting id="cec_standby_screensaver" value="0" />
+    <setting id="cec_wake_screensaver" value="1" />
+    <setting id="connected_device" value="36037" />
+    <setting id="device_name" value="Kodi" />
+    <setting id="device_type" value="1" />
+    <setting id="double_tap_timeout_ms" value="300" />
+    <setting id="enabled" value="1" />
+    <setting id="pause_playback_on_deactivate" value="1" />
+    <setting id="physical_address" value="0" />
+    <setting id="port" value="" />
+    <setting id="send_inactive_source" value="0" />
+    <setting id="standby_devices" value="231" />
+    <setting id="standby_devices_advanced" value="" />
+    <setting id="standby_pc_on_tv_standby" value="13011" />
+    <setting id="standby_tv_on_pc_standby" value="1" />
+    <setting id="tv_vendor" value="0" />
+    <setting id="use_tv_menu_language" value="0" />
+    <setting id="wake_devices" value="231" />
+    <setting id="wake_devices_advanced" value="" />
+</settings>


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #579

Changes :
1. remove the old peripheral_data that is in the incorrect directory, so unusefull
2. put a new one in userdata/peripheral_data which contains configuration to disable tv shutdown

It works in rpi2. I don't known if on other devices, the file is the same. Start kodi and check the ~/.kodi/userdata/peripheral_data if there are some other files

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
