### PR TITLE
dev: fix the grep failure in recalbox-config.sh / fix sync for noobs

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
@@ -440,20 +440,22 @@ if [[ "$command" == "storage" ]]; then
 	) | sed -e s+'^[^:]*: LABEL="\([^"]*\)" UUID="\([^"]*\)" TYPE="[^"]*"$'+'DEV \2 \1'+
 	exit 0
     fi
-    if [[ "$mode" == "INTERNAL" || "$mode" == "ANYEXTERNAL" || "$mode" == "RAM" || "$mode" == "DEV" ]]; then
+    if [[ "${mode}" == "INTERNAL" || "${mode}" == "ANYEXTERNAL" || "${mode}" == "RAM" || "${mode}" == "DEV" ]]; then
 	preBootConfig
-	if [[ "$mode" == "INTERNAL" || "$mode" == "ANYEXTERNAL" || "$mode" == "RAM" ]]; then
-            if [ `grep sharedevice $storageFile` ]; then
-               sed -i "s|sharedevice=.*|sharedevice=$mode|g" $storageFile
+	if [[ "${mode}" == "INTERNAL" || "${mode}" == "ANYEXTERNAL" || "${mode}" == "RAM" ]]; then
+            if grep -qE "^sharedevice=" "${storageFile}"
+	    then
+               sed -i "s|sharedevice=.*|sharedevice=${mode}|g" "${storageFile}"
             else
-               echo "sharedevice=$mode" >> $storageFile
+               echo "sharedevice=${mode}" >> "${storageFile}"
             fi
 	fi
-	if [[ "$mode" == "DEV" ]]; then
-            if [ `grep sharedevice $storageFile` ]; then
-               sed -i "s|sharedevice=.*|sharedevice=$mode $extra1|g" $storageFile
+	if [[ "${mode}" == "DEV" ]]; then
+            if grep -qE "^sharedevice=" "${storageFile}"
+	    then
+               sed -i "s|sharedevice=.*|sharedevice=${mode} $extra1|g" "${storageFile}"
             else
-               echo "sharedevice=$mode $extra1" >> $storageFile
+               echo "sharedevice=${mode} ${extra1}" >> "${storageFile}"
             fi
 	fi
 	postBootConfig

--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-sync.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-sync.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-INTERNAL_DEVICE="/dev/mmcblk0p3"
+storageFile="/boot/recalbox-boot.conf"
+INTERNAL_DEVICE=$(cat "${storageFile}" | grep -E "^internal=" | head -n1 | cut -d'=' -f2)
+test -z "${INTERNAL_DEVICE}" && INTERNAL_DEVICE="/dev/mmcblk0p3"
 
 print_usage() {
     echo "${1} list"
@@ -25,6 +27,7 @@ rs_list() {
     then
 	echo "INTERNAL"
     fi
+    # avoid sd card partitions
     (blkid | grep -vE '^/dev/mmcblk' | grep ': LABEL="'
      blkid | grep -vE '^/dev/mmcblk' | grep -v ': LABEL="' | sed -e s+':'+': LABEL="NO_NAME"'+
     ) | grep -vE "^${RS_CURRENT}:" | sed -e s+'^[^:]*: LABEL="\([^"]*\)" UUID="\([^"]*\)" TYPE="[^"]*"$'+'DEV \2 \1'+
@@ -35,27 +38,17 @@ rs_internal_uid() {
 }
 
 rs_fix_min_dates() {
-  # if somebody has a better idea to replace this function
-
   # the problem :
   # files having date 1970 on ext4 cannot correctly synchronized on fat ;-(
   # rsync based on date on a rpi having no network is a problem, mainly on fat but not only for fat;-()
   # i suggest to disable the sync feature is no correct date is available (thus no network), but i'm not sure people would undertand
 
-  # one idea is to force the rpi to 1980 instead of 1970 at startup
+  # one idea is to force the rpi to 1980 instead of 1970 at startup : done
   # a file created a startup each time at t+60s for example even if different will however not be saved
 
   # ext4 min date : 1901
   # ntfs min date : 1601
   # fat  min date : 1980
-
-  # if the current date is 1970 (rpi with no network and then no date), we cannot really use rsync based on timestamp to backup ;-(
-  # at least, don't force dates
-  YEAR=$(date +%Y)
-  if test "${YEAR}" -lt 2000
-  then
-    return 1
-  fi
 
   # => force date being after 1980 otherwise rsync will not be able to set it (on vfat) (rpi has not clock and most of files date is 1970)
   if ! touch -t 198101010000 /tmp/min_timestamp
@@ -65,6 +58,7 @@ rs_fix_min_dates() {
 
   # i won't force a fixed date while having the same date (at 2 seconds, means being the same content)
   # so, the touch to the current time is a way to randomize dates
+  # keep this while some people could have some old files while the recalbox got date from 1970 before
   find /recalbox/share ! -newer /tmp/min_timestamp | while read X; do touch "${X}"; done
 }
 


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes : none

Changes :
- in case of external device, DEV XXX is set, and the grep command failed adding multiple lines in recalbox-boot.config
- fix the rb-sync.sh to use the correct partition in case of noobs (require more testing)
- clean the rb-sync.sh script even if date 1980 is set in 4.1 (perhaps the date should be put in 1980 - however, rb-sync is still an hidden feature)

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
