### PR TITLE
Add recalbox specific parameters, to avoid mofification from linapple…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for vice 2.4.24. This means support for commodore c64 and other commodore systems
 - Added theme for commodore c64
 - Added two demo ROMs for commodore c64
+- Add linapple specific parameters to start fixing an issue.
 
 ## [4.0.0-beta3][unreleased]
 - Xarcade2jstick button remapped + better support of IPAC encoders

--- a/package/linapple-pie/linapple-pie.mk
+++ b/package/linapple-pie/linapple-pie.mk
@@ -29,14 +29,19 @@ endef
 
 ifeq ($(BR2_PACKAGE_RECALBOX_SYSTEM),y)
 LINAPPLE_PIE_CONFDIR = $(TARGET_DIR)/recalbox/share_init/system/.linapple
+LINAPPLE_PIE_CONFFILE = $(LINAPPLE_PIE_CONFDIR)/linapple.conf
 define LINAPPLE_PIE_INSTALL_TARGET_CMDS
 	cp $(@D)/linapple-pie/linapple $(TARGET_DIR)/usr/bin/
 	mkdir -p $(LINAPPLE_PIE_CONFDIR)
 	cp $(@D)/linapple-pie/Master.dsk $(LINAPPLE_PIE_CONFDIR)/
-	cp $(@D)/linapple-pie/linapple.installed.conf $(LINAPPLE_PIE_CONFDIR)/linapple.conf
-	$(SED) "s|^\(\s*\)Slot 6 Directory =.*|\1Slot 6 Directory = /recalbox/share/roms/apple2|g" $(LINAPPLE_PIE_CONFDIR)/linapple.conf
-	$(SED) "s|^\(\s*\)Save State Directory =.*|\1Save State Directory = /recalbox/share/saves/apple2|g" $(LINAPPLE_PIE_CONFDIR)/linapple.conf
-	$(SED) "s|^\(\s*\)FTP Local Dir =.*|\1FTP Local Dir = /recalbox/share/roms/apple2|g" $(LINAPPLE_PIE_CONFDIR)/linapple.conf
+	cp $(@D)/linapple-pie/linapple.installed.conf $(LINAPPLE_PIE_CONFFILE)
+	$(SED) "s|^\(\s*\)Slot 6 Directory =.*|\1Slot 6 Directory = /recalbox/share/roms/apple2|g" $(LINAPPLE_PIE_CONFFILE)
+	$(SED) "s|^\(\s*\)Save State Directory =.*|\1Save State Directory = /recalbox/share/saves/apple2|g" $(LINAPPLE_PIE_CONFFILE)
+	$(SED) "s|^\(\s*\)FTP Local Dir =.*|\1FTP Local Dir = /recalbox/share/roms/apple2|g" $(LINAPPLE_PIE_CONFFILE)
+	echo -e "\n##########################################################################" >> $(LINAPPLE_PIE_CONFFILE)
+	echo -e "#\tRecalbox specific parameters\n" >> $(LINAPPLE_PIE_CONFFILE)
+	echo -e "\tRecalboxRomDirectory =\t/recalbox/share/roms/apple2" >> $(LINAPPLE_PIE_CONFFILE)
+	echo -e "\tRecalboxSaveDirectory =\t/recalbox/share/saves/apple2" >> $(LINAPPLE_PIE_CONFFILE)
 endef
 else
 LINAPPLE_PIE_STARTUP = /usr/bin/linapple


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [X] You added the changes in CHANGELOG.md
- [X] You choose the right repository branch to make the PR
- [X] You described the PR as below

Changes :
- Added recalbox specific parameters to linapple.conf to avoid directory modification from linapple GUI.
  In fact, when selecting a new directory to load a game or a save, the new directory name is written into linapple.conf.
  The next time linapple is called, it could not find the rom or the saved game.
  Theses parameters will be used as the default recalbox rom & saves paths. 
  As linapple does know them, it does not modify them.

Implementation in configgen will follow.
