### PR TITLE
kodi: joystick trigger autoconfiguration

### DIFF
--- a/package/kodi/0010-kodi-events-axes-uncentered.patch
+++ b/package/kodi/0010-kodi-events-axes-uncentered.patch
@@ -11,7 +11,7 @@ index d3979d2..55d9aa6 100644
    for (std::map<int, SDL_Joystick*>::const_iterator it = m_Joysticks.begin(); it != m_Joysticks.end(); ++it)
    {
      std::string joyName(SDL_JoystickName(it->second));
-@@ -481,6 +483,15 @@ void CJoystick::ApplyAxesConfigs()
+@@ -481,6 +483,19 @@ void CJoystick::ApplyAxesConfigs()
          m_Axes[axis].trigger = it->isTrigger;
          m_Axes[axis].rest = it->rest;
        }
@@ -20,8 +20,12 @@ index d3979d2..55d9aa6 100644
 +      n = SDL_JoystickNumAxes(it->second);
 +      for(i=0; i<n; i++) {
 +       if(m_Axes[i+axesCount].trigger == false) {
-+        m_Axes[i+axesCount].trigger = true;
-+        m_Axes[i+axesCount].rest = SDL_JoystickGetAxis(it->second, i);
++         int delta = SDL_JoystickGetAxis(it->second, i);
++         if(abs(delta) > m_DeadzoneRange) {
++           m_Axes[i+axesCount].trigger = true;
++           m_Axes[i+axesCount].rest = delta;
++           CLog::Log(LOGNOTICE, "Joystick trigger autoconfiguration Joystick=%s Axis=%i (rest=%i)", joyName.c_str(), i, m_Axes[i+axesCount].rest);
++         }
 +       }
 +      }
      }


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Changes :
- The previous kodi joystick patch autoconfiguration was too permisive. Restrict on trigger well pressed buttons only to mark them as trigger.
- Cannot test anymore with a ps4 controller.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
