### PR TITLE
Boot: add a sharewait option in recalbox-boot.conf

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -15,8 +15,20 @@ INTERNALDEVICE=`cat ${SHARECONFFILE} | grep "internal=" | head -n1 | cut -d'=' -
 SHAREDEVICE=`cat ${SHARECONFFILE} | grep "sharedevice=" | head -n1 | cut -d'=' -f2`
 [[ "$?" -ne "0" || "$SHAREDEVICE" == "" ]] && SHAREDEVICE=INTERNAL
 
+getMaxTryConfig() {
+    SHARECONFFILE=${1}
+
+    X=$(grep -E '^[ \t]*sharewait[ \t]*=' "${SHARECONFFILE}" | sed -e s+'^[ \t]*sharewait[ \t]*='+''+)
+    if echo "${X}" | grep -qE '^[0-9][0-9]*$'
+    then
+	echo "${X}"
+	return
+    fi
+    echo 7 # default value
+}
+
 INTERNALDEVICETYPE="ext4" # faster than waiting udev to initialize to get the type
-MAXTRY=5
+MAXTRY=$(getMaxTryConfig "${SHARECONFFILE}")
 NTRY=0
 
 # a recalbox is about 40000 files in *.xz


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below
  
  Boot: add a sharewait option in recalbox-boot.conf to allow recalbox to wait longer the external hdd
  - moreover, increase default value from 5 to 7
  - the drawback is that when the hdd is removed, it waits longer before falling back to the internal hdd

=> because some people don't understand why recalbox won't take their hdd has a shared device.

Related to (put here the others PR in other repositories)
