### PR TITLE
security: default root password as recalboxroot

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S35securepasswd
+++ b/board/recalbox/fsoverlay/etc/init.d/S35securepasswd
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.pyc"
+
 # /etc/shadow is dynamically generated from the password found in /boot/recalbox-boot.conf
 # the password is visible only in the es interface
 # or to people having already a ssh password via the command : /recalbox/scripts/recalbox-config.sh setRootPassword xyz
@@ -13,6 +15,11 @@ then
 fi
 
 # secure ssh
+enabled="`$systemsetting  -command load -key system.security.enabled`"
+if [ "$enabled" != "1" ];then
+    MASTERPASSWD="recalboxroot"
+fi
+  
 # write the /etc/shadow file
 SHADOWPASSWD=$(openssl passwd -1 "${MASTERPASSWD}")
 echo "root:${SHADOWPASSWD}:::::::" > /run/recalbox.shadow

--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
@@ -28,6 +28,13 @@ systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalb
 echo "---- recalbox-config.sh ----" >> $log
 
 if [ "$command" == "getRootPassword" ]; then
+    # security disabled, force the default one without changing boot configuration
+    securityenabled="`$systemsetting  -command load -key system.security.enabled`"
+    if [ "$securityenabled" != "1" ];then
+	echo "recalboxroot"
+	exit 0
+    fi
+    
     ENCPASSWD=$(grep -E '^[ \t]*rootshadowpassword[ \t]*=' "${storageFile}" | sed -e s+'^[ \t]*rootshadowpassword[ \t]*='++)
     if test -z "${ENCPASSWD}"
     then
@@ -43,6 +50,12 @@ fi
 if [ "$command" == "setRootPassword" ]; then
     PASSWD=${2}
 
+    # security disabled, don't change
+    securityenabled="`$systemsetting  -command load -key system.security.enabled`"
+    if [ "$securityenabled" != "1" ];then
+	exit 0
+    fi
+    
     # if no password if provided, generate one
     if test -z "${PASSWD}"
     then


### PR DESCRIPTION
defaults root password as recalboxroot
don't allow password change when security is not set

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
