### PR TITLE
Qtsixa -> do not show mac in controller name

### DIFF
--- a/package/qtsixa-shanwan/qtsixa-shanwan.mk
+++ b/package/qtsixa-shanwan/qtsixa-shanwan.mk
@@ -3,8 +3,8 @@
 # qtsixa-shanwan
 #
 ################################################################################
-QTSIXA_SHANWAN_VERSION = ceef35906f4c894ee0b5b0b3994b956d1f1f643c
-QTSIXA_SHANWAN_SITE = $(call github,yarick123,qtsixa,$(QTSIXA_SHANWAN_VERSION))
+QTSIXA_SHANWAN_VERSION = shanwan
+QTSIXA_SHANWAN_SITE = $(call github,recalbox,qtsixa,$(QTSIXA_SHANWAN_VERSION))
 QTSIXA_SHANWAN_DEPENDENCIES = sdl linux-headers qtsixa
 PKGCONFIG_CONFIG=$(STAGING_DIR)/usr/lib/pkgconfig
 

--- a/package/qtsixa/qtsixa.mk
+++ b/package/qtsixa/qtsixa.mk
@@ -3,7 +3,7 @@
 # qtsixa
 #
 ################################################################################
-QTSIXA_VERSION = 4318a4c696df786893943c80d37ac6d4cfb1abe8
+QTSIXA_VERSION = gasia 
 QTSIXA_SITE = $(call github,recalbox,qtsixa,$(QTSIXA_VERSION))
 QTSIXA_DEPENDENCIES = sdl linux-headers
 PKGCONFIG_CONFIG=$(STAGING_DIR)/usr/lib/pkgconfig


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [X] You choose the right repository branch to make the PR
- [X] You described the PR as below

Fixes https://github.com/recalbox/recalbox-os/issues/924

Changes :
- Remove the mac for controller name.
  I changed the shanwan repo to recalbox one.

Related to https://github.com/recalbox/qtsixa/pull/2 https://github.com/recalbox/qtsixa/pull/1
