### PR TITLE
recalbox-theme package now add only recalbox theme

### DIFF
--- a/package/recalbox-themes/recalbox-themes.mk
+++ b/package/recalbox-themes/recalbox-themes.mk
@@ -9,7 +9,7 @@ RECALBOX_THEMES_SITE = $(call github,recalbox,recalbox-themes,$(RECALBOX_THEMES_
 
 define RECALBOX_THEMES_INSTALL_TARGET_CMDS
         mkdir -p $(TARGET_DIR)/recalbox/share_init/system/.emulationstation/themes/
-	cp -r $(@D)/themes/* \
+	cp -r $(@D)/themes/recalbox \
 		$(TARGET_DIR)/recalbox/share_init/system/.emulationstation/themes/
 endef
 


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [X] You choose the right repository branch to make the PR
- [X] You described the PR as below

Fixes https://github.com/recalbox/recalbox-os/issues/926

Changes :
- only copy recalbox theme on build
