### PR TITLE
Bump Moonlight to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unrelease][unreleased]
-- Update to moonlight-embedded-2.2.0, adds support for GFE 2.11
+- Update to moonlight-embedded-2.2.1 (but still displays 2.2.0 when running), adds support for GFE 2.11
 - Added enet library for moonlight-embedded-2.2.0
 - Solved a bug on xarcade where B and HOTKEY were sending the same event
 - Slide transition by default in ES

--- a/package/moonlight-embedded/moonlight-embedded.mk
+++ b/package/moonlight-embedded/moonlight-embedded.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MOONLIGHT_EMBEDDED_VERSION = 2.2.0
+MOONLIGHT_EMBEDDED_VERSION = 2.2.1
 MOONLIGHT_EMBEDDED_SOURCE = moonlight-embedded-$(MOONLIGHT_EMBEDDED_VERSION).tar.xz
 MOONLIGHT_EMBEDDED_SITE = https://github.com/irtimmer/moonlight-embedded/releases/download/v$(MOONLIGHT_EMBEDDED_VERSION)
 MOONLIGHT_EMBEDDED_DEPENDENCIES = opus expat libevdev avahi alsa-lib udev libcurl libcec ffmpeg sdl2 libenet


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
- Moonlight 2.2.1 (but the bin still generates 2.2.0 .so and displays 2.2.0)

Related to (put here the others PR in other repositories)
