### PR TITLE
S12configs : add the psp and dc config directories.

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S12populateshare
+++ b/board/recalbox/fsoverlay/etc/init.d/S12populateshare
@@ -29,9 +29,10 @@ for FILE in music bios extractions kodi saves screenshots \
             system/.config/lirc/lircd.conf \
             system/.emulationstation/{es_input.cfg,es_settings.cfg} \
             system/{.hatari,.kodi} \
-            system/configs/{fba,mupen64,retroarch,shadersets,moonlight} \
+            system/configs/{fba,moonlight,mupen64,ppsspp,reicast,retroarch,shadersets,xarcade2jstick} \
             system/recalbox.conf
 do
+    # not wanted for kodi
     test -e "$IN""/""$FILE" && test ! -e "$OUT""/""$FILE" && cp -r "$IN""/""$FILE" "$OUT""/""$FILE"
 done
 


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

This is a quick fix to fix the emulators.
But ideally, there a 2 kinds of emu, the one that should not be copied (kodi)
because they support rb upgrade and the others.
We should do like for roms except for kodi.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
