### PR TITLE
add support for usb network interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Slide transition by default in ES
 - Power management switch support (power,reset and LED) for pin 3/5/6
 - Add ifconfig -a and /boot/recalbox-boot.conf in recalbox-support.sh
+- Add support for usb network interfaces
 
 ## [4.0.0-beta3] - 2016-04-19
 - Xarcade2jstick button remapped + better support of IPAC encoders
@@ -39,7 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed system locales
 - Updated 8bitdo gamepads
 - Bumped to moonlight-embedded-2.1.4
-- Overclock set to none now delete lines in config.txt 
+- Overclock set to none now delete lines in config.txt
 - Improved keyboard encoders support
 - Fixed an issue concerning ISO loading taking too long
 
@@ -64,7 +65,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added Chinese and Turkish
 - Added samba switch in recalbox.conf
 - Added WiiMote support
-- Added Kodi controller support 
+- Added Kodi controller support
 - Corrected controller <-> player attribution
 - Added moonlight system support, with roms
 - Added new switch in recalbox.conf for ssh and virtual gamepads
@@ -95,7 +96,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.3.0-beta9] - 2015-10-11
 - Fixed Moonlight theme for zoid
 - Added splashscreen for long reboots
-- Added mplayer and jscal 
+- Added mplayer and jscal
 - Updated atari 2600 stella core for 2 players support
 - Updated fba libretro for R3 diag menu
 - Added xbox 360 official wireless dongle support OOTB
@@ -151,7 +152,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added Vectrex libretro emulator
 - Added Game And Watch libretro emulator
 - Added Lynx libretro emulator
-- Added PRBoom libretro 
+- Added PRBoom libretro
 - Modif zoid theme
 - Patched kernel to support retrobit controllers
 - Patched kernel to support 4NES4SNES controllers
@@ -175,7 +176,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added Tgbdual libretro core
 - Added Miroof's Virtual Gamepads
 - Added silent install
- 
+
 ## [3.2.11] - 2015-03-24
 - Corrected issues with controllers with idientical names
 - Added zoid theme
@@ -187,7 +188,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.2.9] - 2015-03-15
 ### Changed
 - Added fba emulator switch
-- Added snes9x, catsfc, pocketsnes switch 
+- Added snes9x, catsfc, pocketsnes switch
 - Added virtualboy platform
 - Fixed : buttons on axis in retroarch config
 - Added timestamps in logs

--- a/board/recalbox/fsoverlay/etc/init.d/S40network
+++ b/board/recalbox/fsoverlay/etc/init.d/S40network
@@ -9,6 +9,7 @@ case "$1" in
 	/sbin/ifup lo
         /recalbox/scripts/recalbox-config.sh ethernet start
         /recalbox/scripts/recalbox-config.sh wifi start
+        /recalbox/scripts/recalbox-config.sh usbnet start
         ;;
   stop)
         echo -n "Stopping network..."

--- a/board/recalbox/fsoverlay/etc/network/interfaces.base
+++ b/board/recalbox/fsoverlay/etc/network/interfaces.base
@@ -5,6 +5,9 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
 
+auto usb0
+iface usb0 inet dhcp
+
 auto wlan0
 iface wlan0 inet dhcp
 wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf


### PR DESCRIPTION
Everything is in the title.  I would like to get a network access via a USB network interface, so that I can share the network connection of my smartphone with the recalbox box.

This change allows usb network interfaces to be ifuped at startup.  

I am not that much familiar with buildroot, and maybe there is a better way to do this.  For example, it would be nice to be able to mount usb network interfaces after startup.  Kodi currently supports this, but I am not sure how to achieve this in recalbox.  I would happy to add more changes to support this: tips are welcome !!

thanks,
Damien
