### PR TITLE
Added chd to the known file extensions for reicast. CHD enables image…

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/share_init/system/.emulationstation/es_systems.cfg
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/.emulationstation/es_systems.cfg
@@ -176,7 +176,7 @@
         <fullname>Dreamcast</fullname>
         <name>dreamcast</name>
         <path>/recalbox/share/roms/dreamcast</path>
-        <extension>.gdi .GDI .cdi .CDI</extension>
+        <extension>.gdi .GDI .cdi .CDI .chd .CHD</extension>
         <command>python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.pyc %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM% -emulator %EMULATOR% -core %CORE%</command>
         <platform>ignore</platform>
         <theme>dreamcast</theme>


### PR DESCRIPTION
Description:

This change lets emulationstation scan for dreamcast roms with .chd .CHD as known file extension.

A GDI Image can converted to .chd via chdman
An easy utility (gui + chdman) can be downloaded from here
http://forum.xda-developers.com/nvidia-shield/shield-qa/reicast-gdi-to-chd-t2823608

This has the follwing benefits:
- Compression of the disk image
  eg Crazy Taxi GDI (1.1GB) to CHD file (118Mb) 

Changes :
- Added .chd to the known file extensions for reicast
