### PR TITLE
odroid xu4 fan: faster to avoid slow issue

### DIFF
--- a/board/recalbox/fsoverlay_odroid_xu4/etc/init.d/S02fan
+++ b/board/recalbox/fsoverlay_odroid_xu4/etc/init.d/S02fan
@@ -8,7 +8,7 @@ then
   # the default noisy value is to do nothing until 68 degrees, and start at 50%
   # the current temperature : /sys/devices/virtual/thermal/thermal_zone0/temp
   # http://forum.odroid.com/viewtopic.php?f=52&t=16308
-  echo "1 20 50 95" > /sys/devices/odroid_fan.14/fan_speeds
+  echo "1 30 50 95" > /sys/devices/odroid_fan.14/fan_speeds
   echo   "60 70 80" > /sys/devices/odroid_fan.14/temp_levels
 
   # default values :


### PR DESCRIPTION
when the fan is too slow, sometimes it makes a space
noise when starting. several people have the same issue.
this is a minor issue.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
