### PR TITLE
odroid xu4 : image supports sdcard/emmc

### DIFF
--- a/board/hardkernel/odroidxu4/genimage.cfg
+++ b/board/hardkernel/odroidxu4/genimage.cfg
@@ -11,7 +11,7 @@ image boot.vfat {
         size = 64M
 }
 
-image recalbox.sdcard {
+image recalbox.img {
 	hdimage {
 	}
 

--- a/board/recalbox/copy-recalbox-archives.sh
+++ b/board/recalbox/copy-recalbox-archives.sh
@@ -81,9 +81,9 @@ case "${RECALBOX_TARGET}" in
 	# /boot
 	cp "board/hardkernel/odroidxu4/boot.ini" ${BINARIES_DIR}/boot.ini || exit 1
 
-	# recalbox.sdcard
+	# recalbox.img
 	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	RECALBOXIMG="${RECALBOX_BINARIES_DIR}/recalbox.sdcard"
+	RECALBOXIMG="${RECALBOX_BINARIES_DIR}/recalbox.img"
 	rm -rf "${GENIMAGE_TMP}" || exit 1
 	cp "board/hardkernel/odroidxu4/genimage.cfg" "${BINARIES_DIR}" || exit 1
 	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${RECALBOX_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1


### PR DESCRIPTION
the same image supports both, sdcard and emmc,
so, i rename it from recalbox.sdcard to recalbox.img

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
