### PR TITLE
Odroid logo : remove it on the linux boot splash

### DIFF
--- a/board/recalbox/kernel-odroid-3.10-defconfig-fragment.config
+++ b/board/recalbox/kernel-odroid-3.10-defconfig-fragment.config
@@ -1,0 +1,1 @@
+# CONFIG_LOGO is not set

--- a/configs/recalbox-odroidxu4_defconfig
+++ b/configs/recalbox-odroidxu4_defconfig
@@ -31,6 +31,7 @@ BR2_LINUX_KERNEL_CUSTOM_REPO_URL="https://github.com/hardkernel/linux.git"
 BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="odroidxu3-3.10.y"
 BR2_LINUX_KERNEL_PATCH="board/recalbox/kernel_patches_odroidxu4"
 BR2_LINUX_KERNEL_DEFCONFIG="odroidxu3"
+BR2_LINUX_KERNEL_CONFIG_FRAGMENT_FILES="board/recalbox/kernel-odroid-3.10-defconfig-fragment.config"
 BR2_LINUX_KERNEL_DTS_SUPPORT=y
 BR2_LINUX_KERNEL_INTREE_DTS_NAME="exynos5422-odroidxu3"
 BR2_PACKAGE_BUSYBOX_CONFIG_FRAGMENT_FILES="board/recalbox/busybox.custom.config"


### PR DESCRIPTION
this logo is over a white line.
The write line appears and blink sometimes when playing on the left corner (the part not erased by S02splash)
I remove it while it is not necessary and fixes the problem.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
