### PR TITLE
network mounts : network at boot to mount share/bios/roms/saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bumped retroarch to v1.3.4
 - Add ipega 9021 rules
 - ES now shutdowns the system
+- share/roms/saves/bios available via a network point
 
 ## [4.0.0-beta3] - 2016-04-19
 - Xarcade2jstick button remapped + better support of IPAC encoders

--- a/board/recalbox/fsoverlay/etc/init.d/S03populate
+++ b/board/recalbox/fsoverlay/etc/init.d/S03populate
@@ -12,6 +12,7 @@ cp /etc/sixad.profile /var/lib/sixad/profiles/default
 # custom network config
 mkdir -p "/var/lib/connman"
 ln -sf "/recalbox/share/system/network-connman.config" "/var/lib/connman/recalbox-custom.config"
+ln -sf "/boot/network-connman.config"                  "/var/lib/connman/recalbox-boot-custom.config"
 
 # bluetooth
 mkdir -p /var/lib/bluetooth

--- a/board/recalbox/fsoverlay/etc/init.d/S11share
+++ b/board/recalbox/fsoverlay/etc/init.d/S11share
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+if test "$1" = "stop"
+then
+    # umount all network configs
+    # don't just remount the one of the config in case the config changed
+    umount -a -t nfs
+    umount -a -t cifs
+    exit 0
+fi
+
 if test "$1" != "start"
 then
   exit 0
@@ -99,6 +108,101 @@ mountDeviceOrFallback() {
 	    mount -t tmpfs -o size=128M tmpfs /recalbox/share
 	fi
     fi
+}
+
+mountNetwork() {
+    # /boot/recalbox-boot.conf examples :
+    # sharedevice=NETWORK
+    #
+    # Basic commands : sharenetwork_<nfs|smb><[0-9]>=<SHARE|ROMS|SAVES|BIOS>@<host>:<remote directory>:<mount options>
+    #
+    # sharenetwork_nfs1=SHARE@192.168.0.1:/Documents/recalbox
+    # or
+    # sharenetwork_nfs1=ROMS@192.168.0.1:/Documents/recalbox/roms
+    # sharenetwork_nfs2=SAVES@192.168.0.1:/Documents/recalbox/saves
+    # or
+    # sharenetwork_smb1=SHARE@192.168.0.1:Documents/recalbox:guest
+    #
+    # Advanced commands : sharenetwork_cmd<[0-9]>=<command to run>
+    # sharenetwork_cmd1=mount -o port=2049,nolock,proto=tcp 192.168.0.1:/Documents/recalbox /recalbox/share
+    # or
+    # sharenetwork_cmd1=mount -o port=2049,nolock,proto=tcp 192.168.0.1:/Documents/recalbox/roms /recalbox/share/roms
+    # sharenetwork_cmd2=mount -o port=2049,nolock,proto=tcp 192.168.0.1:/Documents/recalbox/saves /recalbox/share/saves
+    # or
+    # sharenetwork_cmd1=mount.cifs //192.168.0.1/recalbox /recalbox/share -o guest
+
+
+    # execute all commands in /boot/recalbox-boot.conf which are like : sharenetwork_cmd1=my command
+    if ! grep -E '^[ ]*sharenetwork_[a-z]*[0-9][ ]*=' "${SHARECONFFILE}" |
+	    sed -e s+'^[ ]*sharenetwork_\([a-z]*\)[0-9][ ]*='+'\1 '+ |
+	    while read CTYPE CMD
+	    do
+		XTRY=5  # X tries and give up
+		XWAIT=4 # N seconds between each try
+
+		while test "${XTRY}" -gt 0
+		do
+		    let XTRY--
+
+		    CMD_EXEC=echo
+		    if test "${CTYPE}" = "cmd"
+		    then
+			CMD_EXEC="${CMD}"
+		    else
+			CMD_TARGET=$(echo "${CMD}" | sed -e s+'^\([^@]*\)@.*$'+'\1'+)
+			CMD_HOST=$(echo "${CMD}" | sed -e s+'^[^@]*@\([^:]*\):.*$'+'\1'+)
+			CMD_RDIR=$(echo "${CMD}" | sed -e s+'^[^@]*@[^:]*:\([^:]*\).*$'+'\1'+)
+			CMD_OPT=$(echo "${CMD}" | sed -e s+'^[^@]*@[^:]*:[^:]*'+''+ -e s+'^:'++)
+
+			# MAP to the recalbox directory
+			CMD_TDIR="/recalbox/share"
+			case "${CMD_TARGET}" in
+			    "SHARE")
+				CMD_TDIR="/recalbox/share"
+			    ;;
+			    "ROMS")
+				CMD_TDIR="/recalbox/share/roms"
+			    ;;
+			    "SAVES")
+				CMD_TDIR="/recalbox/share/saves"
+			    ;;
+			    "BIOS")
+				CMD_TDIR="/recalbox/share/bios"
+			    ;;
+			esac
+
+			case "${CTYPE}" in
+			    "nfs")
+				CMD_ADDOPT=
+				test -n "${CMD_OPT}" && CMD_ADDOPT=",${CMD_OPT}"
+				CMD_EXEC="mount -o port=2049,nolock,proto=tcp${CMD_ADDOPT} ${CMD_HOST}:${CMD_RDIR} ${CMD_TDIR}"
+				;;
+			    "smb")
+				CMD_ADDOPT=
+				test -n "${CMD_OPT}" && CMD_ADDOPT="-o ${CMD_OPT}"
+				CMD_EXEC="mount.cifs //${CMD_HOST}/${CMD_RDIR} ${CMD_TDIR} ${CMD_ADDOPT}"
+				;;
+			esac
+		    fi
+
+		    echo "${CMD_EXEC}" >> /tmp/mountNetwork.log
+		    if ${CMD_EXEC}
+		    then
+			XTRY=0
+		    else
+			# give up
+			if test ${XTRY} = 0
+			then
+			    return 1
+			fi
+			sleep ${XWAIT} # wait n seconds between each try
+		    fi
+		done
+	    done
+    then
+	return 1
+    fi
+    return 0
 }
 
 scr_init_upgrade() {
@@ -218,6 +322,20 @@ case "${MODE}" in
 	;;
     "RAM")
 	mount -t tmpfs -o size=128M tmpfs /recalbox/share
+	;;
+    "NETWORK")
+	# first, INTERNAL mount, then, network mount over the NETWORK mounts
+	# to allow to mount over /recalbox/share, but only over /recalbox/share/roms if wanted
+	# mounting network mounts over usb key have not really sense
+	if ! /recalbox/scripts/recalbox-mount.sh "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /recalbox/share
+	then
+	    # fallback
+	    mount -t tmpfs -o size=128M tmpfs /recalbox/share
+	fi
+
+	# Network mounts
+	# no fallback required, mounted on the share
+	mountNetwork > /tmp/mountNetwork.log 2> /tmp/mountNetwork.err # could be usefull to debug
 	;;
     "INTERNAL"|*)
 	if ! /recalbox/scripts/recalbox-mount.sh "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /recalbox/share

--- a/board/recalbox/fsoverlay/etc/init.d/S98cleanup
+++ b/board/recalbox/fsoverlay/etc/init.d/S98cleanup
@@ -32,4 +32,11 @@ find "/usr/share/kodi/system/keymaps" -name "joystick.*.xml" |
 doClean "/etc/network/interfaces.base"
 doClean "/etc/wpa_supplicant/wpa_supplicant.conf"
 
+# V4.1.0 2016-06-16
+doClean "${TARGET_DIR}/etc/init.d/S10udev"
+doClean "${TARGET_DIR}/etc/init.d/S30dbus"
+doClean "${TARGET_DIR}/etc/init.d/S40network"
+doClean "${TARGET_DIR}/etc/init.d/S45connman"
+
+
 exit 0

--- a/board/recalbox/recalbox-patch-target.sh
+++ b/board/recalbox/recalbox-patch-target.sh
@@ -19,7 +19,14 @@ ln -sf "/recalbox/share_init/system/.emulationstation/es_systems.cfg" "${TARGET_
 ln -sf "/recalbox/share_init/system/.emulationstation/themes"         "${TARGET_DIR}/etc/emulationstation/themes"         || exit 1
 ln -sf "/recalbox/share/cheats"                                       "${TARGET_DIR}/recalbox/share_init/cheats/custom"   || exit 1
 
+# we don't want the kodi startup script
 rm -f "${TARGET_DIR}/etc/init.d/S50kodi" || exit 1
+
+# reorder the boot scripts for the network boot
+mv "${TARGET_DIR}/etc/init.d/S10udev"    "${TARGET_DIR}/etc/init.d/S05udev"    || exit 1 # move to make number spaces
+mv "${TARGET_DIR}/etc/init.d/S30dbus"    "${TARGET_DIR}/etc/init.d/S06dbus"    || exit 1 # move really before for network (connman prerequisite)
+mv "${TARGET_DIR}/etc/init.d/S40network" "${TARGET_DIR}/etc/init.d/S07network" || exit 1 # move to make ifaces up sooner, mainly mountable/unmountable before/after share
+mv "${TARGET_DIR}/etc/init.d/S45connman" "${TARGET_DIR}/etc/init.d/S08connman" || exit 1 # move to make before share
 
 # remove kodi default joystick configuration files
 # while as a minimum, the file joystick.Sony.PLAYSTATION(R)3.Controller.xml makes references to PS4 controllers with axes which doesn't exist (making kodi crashing)


### PR DESCRIPTION
New scripts order:
connman is started before share (S11)

1) S06dbus, S07network, S08connman start very quickly
2) connman is very powerfull, it uses libnotify to be aware of new configuration files.
- when connman start, if it find /boot/network-connman.config, it can uses it to configure eth*, the wifi, or even a vpn
- otherwise, it will uses dhcp over eth0
- when the share is mounted, connman can find /recalbox/share/system/network-connman.config and adapt again the network to the best
  3) all the tested configurations worked

Configuration files :
Networks :
- /recalbox/share/system/network-connman.config (network configuration, already existing, for custom network)
- /boot/network-connman.config (idem, but applied at boot time, before share is mounted. use one or the other one)

Mounts :
- /boot/recalbox-boot.conf
  Examples:
  # /boot/recalbox-boot.conf examples :
  # sharedevice=NETWORK
  #
  # Basic commands : sharenetwork_<nfs|smb><[0-9]>=<SHARE|ROMS|SAVES|BIOS>@<host>:<remote directory>:<mount options>
  #
  # sharenetwork_nfs1=SHARE@192.168.0.1:/Documents/recalbox
  # or
  # sharenetwork_nfs1=ROMS@192.168.0.1:/Documents/recalbox/roms
  # sharenetwork_nfs2=SAVES@192.168.0.1:/Documents/recalbox/saves
  # or
  # sharenetwork_smb1=SHARE@192.168.0.1:Documents/recalbox:guest
  #
  # Advanced commands : sharenetwork_cmd<[0-9]>=<command to run>
  # sharenetwork_cmd1=mount -o port=2049,nolock,proto=tcp 192.168.0.1:/Documents/recalbox /recalbox/share
  # or
  # sharenetwork_cmd1=mount -o port=2049,nolock,proto=tcp 192.168.0.1:/Documents/recalbox/roms /recalbox/share/roms
  # sharenetwork_cmd2=mount -o port=2049,nolock,proto=tcp 192.168.0.1:/Documents/recalbox/saves /recalbox/share/saves
  # or
  # sharenetwork_cmd1=mount.cifs //192.168.0.1/recalbox /recalbox/share -o guest

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
