### PR TITLE
Disable the scan of multitouch (ABS_MT) events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - ES now shutdowns the system
 - share/roms/saves/bios available via a network point
 - bumped SDL to 2.0.4
+- disable multitouch axis in SDL 2.0.4
 - linux kernel bumped to 4.4.13
 - Add DosBox 0.74 (rev 3980) with specific patches: SDL2, with mapping of mouse and all axis of joysticks
 

--- a/package/sdl2/sdl2_input_p005_limit_ABS_max.patch
+++ b/package/sdl2/sdl2_input_p005_limit_ABS_max.patch
@@ -2,6 +2,15 @@ diff --git a/src/joystick/linux/SDL_sysjoystick.c b/src/joystick/linux/SDL_sysjo
 index 0a90d71..31285a8 100644
 --- a/src/joystick/linux/SDL_sysjoystick.c
 +++ b/src/joystick/linux/SDL_sysjoystick.c
+@@ -502,7 +502,7 @@ ConfigJoystick(SDL_Joystick * joystick, int fd)
+                 ++joystick->nbuttons;
+             }
+         }
+-        for (i = 0; i < ABS_MAX; ++i) {
++        for (i = 0; i < ABS_MISC; ++i) {
+             /* Skip hats */
+             if (i == ABS_HAT0X) {
+                 i = ABS_HAT3Y;
 @@ -765,6 +765,9 @@ HandleInputEvents(SDL_Joystick * joystick)
                  }
                  break;

--- a/package/sdl2/sdl2_input_p005_limit_ABS_max.patch
+++ b/package/sdl2/sdl2_input_p005_limit_ABS_max.patch
@@ -1,0 +1,14 @@
+diff --git a/src/joystick/linux/SDL_sysjoystick.c b/src/joystick/linux/SDL_sysjoystick.c
+index 0a90d71..31285a8 100644
+--- a/src/joystick/linux/SDL_sysjoystick.c
++++ b/src/joystick/linux/SDL_sysjoystick.c
+@@ -765,6 +765,9 @@ HandleInputEvents(SDL_Joystick * joystick)
+                 }
+                 break;
+             case EV_ABS:
++                if (code >= ABS_MISC) {
++                    break;
++                }
+                 switch (code) {
+                 case ABS_HAT0X:
+                 case ABS_HAT0Y:


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
- SDL2.0.4 doesn't scan anymore ABS_MT axis (was causing a bug with PS3 clones when reconfiguring pads in ES)

Related to (put here the others PR in other repositories)
