### PR TITLE
Update mupen64plus-input-sdl.mk

### DIFF
--- a/package/mupen64plus-input-sdl/mupen64plus-input-sdl.mk
+++ b/package/mupen64plus-input-sdl/mupen64plus-input-sdl.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MUPEN64PLUS_INPUT_SDL_VERSION = 4cac18ba2188654d68c237a4bc7864e8be6147ba
+MUPEN64PLUS_INPUT_SDL_VERSION = dfbb873df027a823e541752a19a3df2921a22233
 MUPEN64PLUS_INPUT_SDL_SITE = $(call github,mupen64plus,mupen64plus-input-sdl,$(MUPEN64PLUS_INPUT_SDL_VERSION))
 MUPEN64PLUS_INPUT_SDL_LICENSE = MIT
 MUPEN64PLUS_INPUT_SDL_DEPENDENCIES = sdl2 alsa-lib rpi-userland mupen64plus-core


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [ ] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX
It´s related to recalbox/recalbox-os#941

Changes :

Matching code updated to differentiate gamepads with exact names but the number of spaces at the end. For example , 8bitdo´s Nes30 Pro and Zero have the following device names: [Bluetooth Wireless Controller ] is the Nes30 Pro and [Bluetooth Wireless Controller] is the Zero
This should allow mupen64plus to use both controllers at the same time.

Related to (put here the others PR in other repositories)

mupen64plus/mupen64plus-core#152

Update to the latest commit
https://github.com/mupen64plus/mupen64plus-input-sdl/commits/master
