### PR TITLE
joystick: fix the wiimote controller extension with sdl 2.0.4

### DIFF
--- a/board/recalbox/fsoverlay/etc/udev/rules.d/99-wiimote.rules
+++ b/board/recalbox/fsoverlay/etc/udev/rules.d/99-wiimote.rules
@@ -1,2 +1,2 @@
 SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
-SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
+SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_KEY}="0"


### PR DESCRIPTION
in sdl 2.0.4, if ID_INPUT_KEY and ID_INPUT_JOYSTICK are defined, a linux event (/dev/input/*) is both a joystick and a keyboard.
so, for 1 linux event, sdl produces 2 events.
At the end, es sees 2 events.
In my case, the wiimote button value is the arrow bottom keys.
At the end, es go down 2 times in the lists for 1 button on the down button.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
