### PR TITLE
SDL_sound: patch to use SDL2 instead of SDL

### DIFF
--- a/package/sdl_sound/0003-use-sdl2.patch
+++ b/package/sdl_sound/0003-use-sdl2.patch
@@ -1,0 +1,25 @@
+Patch sources to compile on SDL2, instead of SDL.
+See: http://hg.icculus.org/icculus/SDL_sound/shortlog
+
+--- a/playsound/playsound.c	Wed Aug 15 23:48:59 2012 -0400
++++ b/playsound/playsound.c	Wed Aug 15 23:52:18 2012 -0400
+@@ -84,12 +84,18 @@
+     Sound_Version compiled;
+     Sound_Version linked;
+     SDL_version sdl_compiled;
+-    const SDL_version *sdl_linked;
++    SDL_version sdl_linked_ver;
++    const SDL_version *sdl_linked = &sdl_linked_ver;
+ 
+     SOUND_VERSION(&compiled);
+     Sound_GetLinkedVersion(&linked);
+     SDL_VERSION(&sdl_compiled);
++
++    #if SDL_MAJOR_VERSION >= 2
++    SDL_GetVersion(&sdl_linked_ver);
++    #else
+     sdl_linked = SDL_Linked_Version();
++    #endif
+ 
+     fprintf(stdout,
+            "%s version %d.%d.%d\n"

--- a/package/sdl_sound/Config.in
+++ b/package/sdl_sound/Config.in
@@ -1,6 +1,6 @@
 config BR2_PACKAGE_SDL_SOUND
 	bool "SDL_sound"
-	depends on BR2_PACKAGE_SDL
+	depends on BR2_PACKAGE_SDL2
 	select BR2_PACKAGE_LIBICONV if !BR2_ENABLE_LOCALE
 	help
 	  SDL_sound is a library that handles the decoding of several

--- a/package/sdl_sound/sdl_sound.mk
+++ b/package/sdl_sound/sdl_sound.mk
@@ -17,16 +17,32 @@ SDL_SOUND_DEPENDENCIES += libiconv
 endif
 
 # optional dependencies
-ifeq ($(BR2_PACKAGE_FLAC),y)
-SDL_SOUND_DEPENDENCIES += flac # is only used if ogg is also enabled
+ifeq ($(BR2_PACKAGE_FLAC)$(BR2_PACKAGE_LIBOGG),yy)
+SDL_SOUND_CONF_OPTS += --enable-flac
+SDL_SOUND_DEPENDENCIES += flac libogg
+else
+SDL_SOUND_CONF_OPTS += --disable-flac
+endif
+
+ifeq ($(BR2_PACKAGE_LIBMODPLUG),y)
+SDL_SOUND_CONF_OPTS += --enable-modplug
+SDL_SOUND_DEPENDENCIES += libmodplug
+else
+SDL_SOUND_CONF_OPTS += --disable-modplug
 endif
 
 ifeq ($(BR2_PACKAGE_LIBVORBIS),y)
+SDL_SOUND_CONF_OPTS += --enable-ogg
 SDL_SOUND_DEPENDENCIES += libvorbis
+else
+SDL_SOUND_CONF_OPTS += --disable-ogg
 endif
 
 ifeq ($(BR2_PACKAGE_SPEEX),y)
+SDL_SOUND_CONF_OPTS += --enable-speex
 SDL_SOUND_DEPENDENCIES += speex
+else
+SDL_SOUND_CONF_OPTS += --disable-speex
 endif
 
 SDL_SOUND_CONF_OPTS = \

--- a/package/sdl_sound/sdl_sound.mk
+++ b/package/sdl_sound/sdl_sound.mk
@@ -10,39 +10,23 @@ SDL_SOUND_SITE = http://icculus.org/SDL_sound/downloads
 SDL_SOUND_LICENSE = LGPLv2.1+
 SDL_SOUND_LICENSE_FILES = COPYING
 SDL_SOUND_INSTALL_STAGING = YES
-SDL_SOUND_DEPENDENCIES = sdl
+SDL_SOUND_DEPENDENCIES = sdl2
 
 ifneq ($(BR2_ENABLE_LOCALE),y)
 SDL_SOUND_DEPENDENCIES += libiconv
 endif
 
 # optional dependencies
-ifeq ($(BR2_PACKAGE_FLAC)$(BR2_PACKAGE_LIBOGG),yy)
-SDL_SOUND_CONF_OPTS += --enable-flac
-SDL_SOUND_DEPENDENCIES += flac libogg
-else
-SDL_SOUND_CONF_OPTS += --disable-flac
-endif
-
-ifeq ($(BR2_PACKAGE_LIBMODPLUG),y)
-SDL_SOUND_CONF_OPTS += --enable-modplug
-SDL_SOUND_DEPENDENCIES += libmodplug
-else
-SDL_SOUND_CONF_OPTS += --disable-modplug
+ifeq ($(BR2_PACKAGE_FLAC),y)
+SDL_SOUND_DEPENDENCIES += flac # is only used if ogg is also enabled
 endif
 
 ifeq ($(BR2_PACKAGE_LIBVORBIS),y)
-SDL_SOUND_CONF_OPTS += --enable-ogg
 SDL_SOUND_DEPENDENCIES += libvorbis
-else
-SDL_SOUND_CONF_OPTS += --disable-ogg
 endif
 
 ifeq ($(BR2_PACKAGE_SPEEX),y)
-SDL_SOUND_CONF_OPTS += --enable-speex
 SDL_SOUND_DEPENDENCIES += speex
-else
-SDL_SOUND_CONF_OPTS += --disable-speex
 endif
 
 SDL_SOUND_CONF_OPTS = \
@@ -56,6 +40,14 @@ SDL_SOUND_CONF_OPTS += --enable-mmx
 else
 SDL_SOUND_CONF_OPTS += --disable-mmx
 endif
+
+define SDL_SOUND_PATCH_CONFIGURE
+	(cd $(@D); \
+	sed -ie 's/sdl-config/sdl2-config/g' configure \
+	)
+endef
+
+SDL_SOUND_PRE_CONFIGURE_HOOKS += SDL_SOUND_PATCH_CONFIGURE
 
 define SDL_SOUND_REMOVE_PLAYSOUND
 	rm $(addprefix $(TARGET_DIR)/usr/bin/,playsound playsound_simple)


### PR DESCRIPTION
This patch allows SDL_sound to be compiled with SDL2 instead of SDL1.
It allows DosBox (now compiled with SDL2 too) to decode compressed audio files (OGG) in IMGMOUNT.

Indeed, it is not possible to use in a same application SDL2 and SDL_sound, compiled with SDL1.

In previous versions of RecalBox, SDL_sound was not used. In 4.1, the only dependence is DosBox. So, no impact expected !

For more information, please consult: http://www.vogons.org/viewtopic.php?f=32&t=34770&sid=ed1915709f4262832c27d886b3160a06&start=52
