### PR TITLE
DosBox: Bug resolved - Now allow to CHDIR C:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - share/roms/saves/bios available via a network point
 - bumped SDL to 2.0.4
 - linux kernel bumped to 4.4.13
-- Add DosBox 0.74 (rev 3980) with specific patches: SDL2, with mapping of mouse and all axis of joysticks
+- Add DosBox 0.74 (rev 3989) with specific patches: SDL2, with mapping of mouse and all axis of joysticks
 
 ## [4.0.0-beta3] - 2016-04-19
 - Xarcade2jstick button remapped + better support of IPAC encoders

--- a/package/dosbox/Config.in
+++ b/package/dosbox/Config.in
@@ -7,7 +7,6 @@ config BR2_PACKAGE_DOSBOX
         select BR2_PACKAGE_LIBOGG
         select BR2_PACKAGE_LIBVORBIS
         select BR2_PACKAGE_SDL_SOUND
-        select BR2_PACKAGE_SDL_NET
 
 	help
 	  DOSBox is a DOS-emulator that uses the SDL-library 

--- a/package/dosbox/dosbox-005-bug-chdir.patch
+++ b/package/dosbox/dosbox-005-bug-chdir.patch
@@ -1,0 +1,16 @@
+This modification has been introduced in revision 3616 but crashes LBA 2,
+ which uses a CHDIR C:.
+
+Signed-off-by: Laurent Merckx <laurent-merckx@skynet.be>
+
+--- dosbox/src/dos/dos_files.cpp.o	2016-07-06 14:21:34.929300170 +0200
++++ dosbox.n/src/dos/dos_files.cpp	2016-07-06 14:21:46.009300114 +0200
+@@ -206,7 +206,7 @@ bool DOS_GetCurrentDir(Bit8u drive,char
+ bool DOS_ChangeDir(char const * const dir) {
+ 	Bit8u drive;char fulldir[DOS_PATHLENGTH];
+ 	const char * testdir=dir;
+-	if (strlen(testdir) && testdir[1]==':') testdir+=2;
++	/*if (strlen(testdir) && testdir[1]==':') testdir+=2;*/
+ 	size_t len=strlen(testdir);
+ 	if (!len) {
+ 		DOS_SetError(DOSERR_PATH_NOT_FOUND);

--- a/package/dosbox/dosbox.mk
+++ b/package/dosbox/dosbox.mk
@@ -5,12 +5,12 @@
 ################################################################################
 
 DOSBOX_VERSION_TAG = 0.74
-DOSBOX_VERSION = r3980
+DOSBOX_VERSION = r3989
 DOSBOX_SITE =  svn://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk 
 DOSBOX_SITE_METHOD = svn
 DOSBOX_LICENSE = GPL2
 DOSBOX_LICENSE_FILES = COPYING
-DOSBOX_DEPENDENCIES = sdl2 zlib libpng libogg libvorbis sdl_sound sdl_net
+DOSBOX_DEPENDENCIES = sdl2 zlib libpng libogg libvorbis sdl_sound
 
 DOSBOX_LDFLAGS = -L$(STAGING_DIR)/usr/lib
 DOSBOX_CFLAGS = -I$(STAGING_DIR)/usr/include -I$(STAGING_DIR)/usr/include/SDL2 -I$(STAGING_DIR)/usr/include/SDL
@@ -24,6 +24,7 @@ define DOSBOX_CONFIGURE_CMDS
                 CPPFLAGS="$(TARGET_CPPFLAGS) $(DOSBOX_CFLAGS)" \
                 LDFLAGS="$(TARGET_LDFLAGS) $(DOSBOX_LDFLAGS)" \
                 CROSS_COMPILE="$(HOST_DIR)/usr/bin/" \
+		LIBS="-lvorbisfile -lvorbis -logg" \
                 ./configure --host=arm-buildroot-linux-gnueabihf \
                 --enable-core-inline --prefix=/usr \
                 --enable-dynrec --enable-unaligned_memory \
@@ -35,6 +36,5 @@ define DOSBOX_CONFIGURE_CMDS
         echo "#define C_UNALIGNED_MEMORY 1" >>config.h \
         )
 endef
-
 
 $(eval $(autotools-package))


### PR DESCRIPTION
Bug resolved: Now allow to CHDIR C: (was removed just after version 0.74). 
But cause crash of LBA2 (GOG version).

Also upgrade to revision 3989
