### PR TITLE
Rb 4.1.x fix lutro makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unrelease][unreleased]
+- Fixing Makelfiles for compilation of libretro-lutro for the bump to release  2377dd37ad3bd37ddef9fc37742bba2531a78407 
 - Bump retroarch to last release due to integration of libretro-imageviewer in its cores, and delation of the libretro-imageviewer repos
 - Update Mame2003 core to get the mame2003-skip_warnings and avoid splash screen
 - New emulator : PPSSPP

--- a/package/libretro-lutro/Makefile.patch
+++ b/package/libretro-lutro/Makefile.patch
@@ -1,9 +1,11 @@
---- a/Makefile	2015-05-19 12:47:40.877553797 +0200
-+++ b/Makefile	2015-05-19 11:10:05.000000000 +0200
-@@ -79,6 +79,33 @@
-    CFLAGS += -I$(shell psp-config --pspsdk-path)/include
+--- a/Makefile	2016-07-26 08:57:48.949430075 +0200
++++ b/Makefile	2016-07-26 09:16:20.325450940 +0200
+@@ -184,6 +184,35 @@
     LUA_MYCFLAGS := $(DEFINES) $(CFLAGS)
-    STATIC_LINKING = 1
+ 	STATIC_LINKING = 1
+    MMD :=
++
++#RaspberryPi
 +else ifneq (,$(findstring armv,$(platform)))
 +   TARGET := $(TARGET_NAME)_libretro.so
 +   SHARED := -shared -Wl,--no-undefined
@@ -33,4 +35,4 @@
 +   CFLAGS += -DARM
  else
     CC = gcc
-    TARGET := $(TARGET_NAME)_retro.dll
+    TARGET := $(TARGET_NAME)_libretro.dll

--- a/package/libretro-lutro/MakefileLua.patch
+++ b/package/libretro-lutro/MakefileLua.patch
@@ -1,0 +1,11 @@
+--- a/deps/lua/src/Makefile.orig	2016-07-26 09:42:38.077480560 +0200
++++ b/deps/lua/src/Makefile	2016-07-26 09:43:07.913481120 +0200
+@@ -8,7 +8,7 @@
+ PLAT= none
+ 
+ CC= gcc
+-CFLAGS= -O2 -Wall $(MYCFLAGS)
++CFLAGS= -O2 -Wall $(MYCFLAGS) -fPIC
+ AR= ar rcu
+ RANLIB= ranlib
+ RM= rm -f

--- a/package/libretro-lutro/MakefileLua.patch
+++ b/package/libretro-lutro/MakefileLua.patch
@@ -1,4 +1,4 @@
---- a/deps/lua/src/Makefile.orig	2016-07-26 09:42:38.077480560 +0200
+--- a/deps/lua/src/Makefile	2016-07-26 09:42:38.077480560 +0200
 +++ b/deps/lua/src/Makefile	2016-07-26 09:43:07.913481120 +0200
 @@ -8,7 +8,7 @@
  PLAT= none


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [X] You added the changes in CHANGELOG.md
- [X] You choose the right repository branch to make the PR
- [X] You described the PR as below

Fixes # Makefiles patch errors and linking error dur to missing -fPIC option in lua compilation

Changes :
- Makefile.patch and /deps/lua/src/Makefile
- adding MakefileLua.patch

Related to PR #418 
