### PR TITLE
Added bit and sampling rate info for emulation station bgmusic files

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/share_init/music/readme.txt
+++ b/board/recalbox/fsoverlay/recalbox/share_init/music/readme.txt
@@ -1,1 +1,2 @@
 Place your mp3 files here to replace default bg music in emulationstation.
+The files must have a sampling rate of 44100Hz and shouldn't have a higher bit rate than 256 kb/s.


### PR DESCRIPTION
Added some more explanation on the background music readme.txt

I heard only something like white noise in the emulation station menu due to an unsupported bitrate.
