### PR TITLE
Disable printer sharing to reduce log output + forbid MacOS .DS_store folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated libretro mame 2003 core. Fixes the ratio issue in mame.
 - Improved pads and gpio support for moonlight
 - Change location of PM2_HOME to fix a bug with API daemon
+- Disable printer sharing to reduce log output
 
 ## [4.0.0-beta4] - 2016-06-19
 - Update to moonlight-embedded-2.2.1 (but still displays 2.2.0 when running), adds support for GFE 2.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Improved pads and gpio support for moonlight
 - Change location of PM2_HOME to fix a bug with API daemon
 - Disable printer sharing to reduce log output
+- Prevent MacOS from adding its .DS_store
 
 ## [4.0.0-beta4] - 2016-06-19
 - Update to moonlight-embedded-2.2.1 (but still displays 2.2.0 when running), adds support for GFE 2.11

--- a/board/recalbox/fsoverlay/etc/samba/smb.conf
+++ b/board/recalbox/fsoverlay/etc/samba/smb.conf
@@ -55,6 +55,11 @@
 # to IP addresses
 ;   name resolve order = lmhosts host wins bcast
 
+# Disable printer sharing
+   printcap name = /dev/null
+   load printers = no
+   printing = bsd
+
 #### Networking ####
 
 # The specific set of interfaces / networks to bind to

--- a/board/recalbox/fsoverlay/etc/samba/smb.conf
+++ b/board/recalbox/fsoverlay/etc/samba/smb.conf
@@ -344,3 +344,5 @@ guest ok = yes
 create mask = 0644
 directory mask = 0755
 force user = root
+veto files = /._*/.DS_Store/
+delete veto files = yes


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes :
- https://github.com/recalbox/recalbox-os/issues/988
- https://github.com/recalbox/recalbox-os/issues/962

Changes :
- disabled printer sharing
- prevent MacOS from storing .DS_store folders (won't delete existing ones though)

Related to (put here the others PR in other repositories)
