### PR TITLE
Add custom resolution for ES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add new Traditional Chinese Language
 - Add DosBox 0.74 (rev 3989) with specific patches: SDL2, with mapping of mouse and all axis of joysticks
 - Add lutro extension
+- Add a recalbox.conf option to set a video mode only for es
 
 ## [4.0.0-beta3] - 2016-04-19
 - Xarcade2jstick button remapped + better support of IPAC encoders

--- a/board/recalbox/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/recalbox/fsoverlay/etc/init.d/S31emulationstation
@@ -8,7 +8,10 @@ systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalb
 case "$1" in
   start)
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
+	videoMode="`$systemsetting  -command load -key system.es.videomode`"
         if [ "$enabled" != "0" ];then
+		echo $videoMode | grep -qE "(CEA|DMT) [0-9]{1,2} (HDMI|DVI)"
+		[ $? = "0" ] && tvservice -e "$videoMode"
 		settings_lang="`$systemsetting -command load -key system.language`"
         	recallog "starting emulationstation with lang = $settings_lang"
                 command="HOME=/recalbox/share/system LC_ALL=\"${settings_lang}.UTF-8\" SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so SDL_VIDEO_EGL_DRIVER=/usr/lib/libGLESv2.so SDL_NOMOUSE=1 /usr/bin/emulationstation"
@@ -30,5 +33,4 @@ case "$1" in
 esac
 
 exit $?
-
 

--- a/package/recalbox-system/rpi1/recalbox.conf
+++ b/package/recalbox-system/rpi1/recalbox.conf
@@ -27,6 +27,10 @@ system.security.enabled=0
 ## Recalbox API (REST)
 system.api.enabled=0
 
+## Allow a specific resolution for ES only from the command : tvservice -m [MODE]
+## Leave commented for the default usual behaviour
+;system.es.videomode=CEA 4 HDMI
+
 ## EmulationStation menu style 
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/recalbox-system/rpi2/recalbox.conf
+++ b/package/recalbox-system/rpi2/recalbox.conf
@@ -27,6 +27,10 @@ system.security.enabled=0
 ## Recalbox API (REST)
 system.api.enabled=0
 
+## Allow a specific resolution for ES only from the command : tvservice -m [MODE]
+## Leave commented for the default usual behaviour
+;system.es.videomode=CEA 4 HDMI
+
 ## EmulationStation menu style 
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/recalbox-system/rpi3/recalbox.conf
+++ b/package/recalbox-system/rpi3/recalbox.conf
@@ -27,6 +27,10 @@ system.security.enabled=0
 ## Recalbox API (REST)
 system.api.enabled=0
 
+## Allow a specific resolution for ES only from the command : tvservice -m [MODE]
+## Leave commented for the default usual behaviour
+;system.es.videomode=CEA 4 HDMI
+
 ## EmulationStation menu style 
 ## default -> default all options menu
 ## none -> no menu except the game search menu


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
- add system.es.videomode in recalbox.conf to set a screen resolution only for es
## \- S31emulationstation checks if it should switch the resolution or not

Related to (put here the others PR in other repositories)
https://github.com/recalbox/recalbox-configgen/pull/81

As the configgen PR is also related to overlays, the overlays dir structure will come in a later PR
