### PR TITLE
Update powerswitch.sh

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/scripts/powerswitch.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/powerswitch.sh
@@ -209,6 +209,20 @@ wittyPi_stop()
     gpio mode $halt_pin up
 }
 
+pin356_start()
+{
+	python /recalbox/scripts/rpi-pin356-power.py &
+    pid=$!
+    echo "$pid" > /tmp/rpi-pin356-power.pid
+    wait "$pid"
+}
+pin356_stop()
+{
+    if [[ -f /tmp/rpi-pin356-power.pid ]]; then
+        kill `cat /tmp/rpi-pin356-power.pid`
+    fi
+}
+
 pin56_start()
 {
     mode=$1


### PR DESCRIPTION
Please make sure your PR is ready to be merged !

Changes :
- For some reason (problem when merging 4.0 with 4.1?) the script for launching pin356 was missing in 4.1
## \- only the start and stop was missing, parameter in case at the end is there and the python script is in /recalbox/scripts.
