### PR TITLE
Update SNES button mapping to match NES (A, B)

### DIFF
--- a/package/gamecon_gpio_rpi/gamecon_gpio_rpi.c
+++ b/package/gamecon_gpio_rpi/gamecon_gpio_rpi.c
@@ -422,7 +422,7 @@ static void gc_gcube_process_packet(struct gc *gc)
 #define GC_NES_LATCH	0x800
 
 static const unsigned char gc_nes_bytes[] = { 0, 1, 2, 3 };
-static const unsigned char gc_snes_bytes[] = { 8, 0, 2, 3, 9, 1, 10, 11 };
+static const unsigned char gc_snes_bytes[] = { 0, 1, 2, 3, 8, 9, 10, 11 };
 static const short gc_snes_btn[] = {
 	BTN_A, BTN_B, BTN_SELECT, BTN_START, BTN_X, BTN_Y, BTN_TL, BTN_TR
 };


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #1

Changes 
- SNES button mapping updated to match NES buttons (eg: NES A = SNES A, NES B = SNES B)
## \- Allows NES and SNES controllers to share the same controller port using a simple plug one-to-one adapter without requiring unique ES controller profiles

Related to (put here the others PR in other repositories)
