### PR TITLE
Updated fba-libretro core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added ColecoVison support to bluemsx libretro core
 - Added the alternative N64 core GLupeN64 on rpi2/rpi3
 - Added IPF format support to libretro-hatari (atarist ST)
+- Updated libretro-fba core from FBA 0.2.97.37 to FBA 0.2.97.38
 
 ## [4.0.0-beta5] - 2016-08-13
 - Updated libretro mame 2003 core. Fixes the ratio issue in mame.

--- a/package/libretro-fba/libretro-fba.mk
+++ b/package/libretro-fba/libretro-fba.mk
@@ -3,7 +3,7 @@
 # FBA
 #
 ################################################################################
-LIBRETRO_FBA_VERSION = 314111bdc01da6fc46e3ef80888ddf6a829ee7a7
+LIBRETRO_FBA_VERSION = 8e3768c7bde9f60baefd4b3697ebc6d9e0b65735
 LIBRETRO_FBA_SITE = $(call github,libretro,libretro-fba,$(LIBRETRO_FBA_VERSION))
 
 ifeq ($(BR2_cortex_a7),y)

--- a/package/libretro-fba/libretro-fba.mk
+++ b/package/libretro-fba/libretro-fba.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 LIBRETRO_FBA_VERSION = ab2c68588ef1d0ce2e2fbb3017a5f0763ea3d472
-LIBRETRO_FBA_SITE = $(call github,libretro,libretro-fba,$(LIBRETRO_FBA_VERSION))
+LIBRETRO_FBA_SITE = $(call github,libretro,fbalpha,$(LIBRETRO_FBA_VERSION))
 
 ifeq ($(BR2_cortex_a7),y)
 	LIBRETRO_FBA_PLATFORM=rpi2

--- a/package/libretro-fba/libretro-fba.mk
+++ b/package/libretro-fba/libretro-fba.mk
@@ -3,7 +3,7 @@
 # FBA
 #
 ################################################################################
-LIBRETRO_FBA_VERSION = 8e3768c7bde9f60baefd4b3697ebc6d9e0b65735
+LIBRETRO_FBA_VERSION = ab2c68588ef1d0ce2e2fbb3017a5f0763ea3d472
 LIBRETRO_FBA_SITE = $(call github,libretro,libretro-fba,$(LIBRETRO_FBA_VERSION))
 
 ifeq ($(BR2_cortex_a7),y)


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes https://github.com/recalbox/recalbox-os/issues/943

Changes :
- fba_libretro 0.2.97.38, based on mame 0.173 (instead of 0.167)
- CPS3 is now friendly towards RPi
- Support for Unibios 3.2
- Fixed all savestate issues
- Fix Namco sound
- Handle NeoGeo games with specific Bios (Ironclad)
- Fix NeoGeo games that need UniBios to work
- Fix some regressions

Related to (put here the others PR in other repositories)
https://github.com/libretro/fbalpha
