### PR TITLE
S50dropbear : kill existing connections at stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated libretro-fba core from FBA 0.2.97.37 to FBA 0.2.97.38
 - Added Mad Catz C.T.R.L.R udev rules
 - Add configs to recalbox-support.sh
+- S50dropbear kills existing SSH connection at stop
 
 ## [4.0.0-beta5] - 2016-08-13
 - Updated libretro mame 2003 core. Fixes the ratio issue in mame.

--- a/package/dropbear/S50dropbear
+++ b/package/dropbear/S50dropbear
@@ -44,7 +44,9 @@ start() {
 stop() {
 	printf "Stopping dropbear sshd: "
 	start-stop-daemon -K -q -p /var/run/dropbear.pid
-	[ $? = 0 ] && echo "OK" || echo "FAIL"
+	ret=$?
+	[ $ret = 0 ] && killall -q -15 dropbear 2>/dev/null
+	[ $ret = 0 ] && echo "OK" || echo "FAIL"
 }
 restart() {
 	stop


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
- kill existing connections at stop. See below for details

Related to (put here the others PR in other repositories)

Dropbear forks on new connections. The init.d script simply kills the main 1st process which just listens to incoming connections and forks to handle them. Now we also kill forked dropbear processes, so that, on exit, existing connection are closed instead of stalled
