### PR TITLE
Add Dualshock 4 BT pad support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added Mad Catz C.T.R.L.R udev rules
 - Add configs to recalbox-support.sh
 - Add firmwares ASUS BT400 and Qualcomm Atheros AR3011 BT3.0
+- Add support for PS4 Dualshock4 bluetooth controllers
 
 ## [4.0.0-beta5] - 2016-08-13
 - Updated libretro mame 2003 core. Fixes the ratio issue in mame.

--- a/board/recalbox/kernel_patches_4.4/linux-ds4-bt.patch
+++ b/board/recalbox/kernel_patches_4.4/linux-ds4-bt.patch
@@ -1,0 +1,16 @@
+--- a/drivers/hid/hid-sony.c
++++ b/drivers/hid/hid-sony.c
+@@ -1139,11 +1139,11 @@ static __u8 *sony_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 	 * the gyroscope values to corresponding axes so we need a
+ 	 * modified one.
+ 	 */
+-	if ((sc->quirks & DUALSHOCK4_CONTROLLER_USB) && *rsize == 467) {
++	if (sc->quirks & DUALSHOCK4_CONTROLLER_USB) {
+ 		hid_info(hdev, "Using modified Dualshock 4 report descriptor with gyroscope axes\n");
+ 		rdesc = dualshock4_usb_rdesc;
+ 		*rsize = sizeof(dualshock4_usb_rdesc);
+-	} else if ((sc->quirks & DUALSHOCK4_CONTROLLER_BT) && *rsize == 357) {
++	} else if (sc->quirks & DUALSHOCK4_CONTROLLER_BT) {
+ 		hid_info(hdev, "Using modified Dualshock 4 Bluetooth report descriptor\n");
+ 		rdesc = dualshock4_bt_rdesc;
+ 		*rsize = sizeof(dualshock4_bt_rdesc);


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes https://github.com/recalbox/recalbox-os/issues/456

Changes :
- add PS4 Pad bt connectivity for any firmware

Related to (put here the others PR in other repositories)

Tested and confirmed working
Dunno if we could backport it for XU4 current 3.10 kernel
This patch removes a check on the size of the pad firmware, making it bullet-proof for any pad update
