### PR TITLE
dosbox: add readme files, and the pc directory

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S12populateshare
+++ b/board/recalbox/fsoverlay/etc/init.d/S12populateshare
@@ -33,7 +33,7 @@ for FILE in music bios extractions kodi saves screenshots \
             system/.config/lirc/lircd.conf \
             system/.emulationstation/{es_input.cfg,es_settings.cfg} \
             system/{.hatari,.kodi} \
-            system/configs/{fba,moonlight,mupen64,ppsspp,reicast,retroarch,shadersets,xarcade2jstick} \
+            system/configs/{fba,moonlight,mupen64,ppsspp,reicast,retroarch,shadersets,xarcade2jstick,dosbox} \
             system/recalbox.conf \
             bios/mame2003
 do

--- a/board/recalbox/fsoverlay/recalbox/share_init/roms/pc/_lisezmoi.txt
+++ b/board/recalbox/fsoverlay/recalbox/share_init/roms/pc/_lisezmoi.txt
@@ -1,0 +1,17 @@
+## RECALBOX - PC ##
+
+Placez ici vos jeux pc.
+
+Chaque jeu doit être contenu dans un dossier ayant l'extension .pc.
+Dans chaque dossier, un fichier dosbox.bat doit comporter la ligne de commande à lancer.
+
+Par exemple :
+miniputt.pc/
+miniputt.pc/dosbox.bat
+miniputt.pc/MP.DAT
+miniputt.pc/MP.EXE
+
+Et dosbox.bat contient : MP.EXE
+
+Vous pouvez télécharger les jeux dos à l'adresse :
+http://www.myabandonware.com/browse/platform/dos/

--- a/board/recalbox/fsoverlay/recalbox/share_init/roms/pc/_lisezmoi.txt
+++ b/board/recalbox/fsoverlay/recalbox/share_init/roms/pc/_lisezmoi.txt
@@ -13,5 +13,7 @@ miniputt.pc/MP.EXE
 
 Et dosbox.bat contient : MP.EXE
 
+Pour quitter un jeu, appuyer sur ctrl+f9.
+
 Vous pouvez télécharger les jeux dos à l'adresse :
 http://www.myabandonware.com/browse/platform/dos/

--- a/board/recalbox/fsoverlay/recalbox/share_init/roms/pc/_readme.txt
+++ b/board/recalbox/fsoverlay/recalbox/share_init/roms/pc/_readme.txt
@@ -1,0 +1,18 @@
+## RECALBOX - PC ##
+
+Put your dos games in this directory.
+
+Each game must be placed in a directory having the .pc extension.
+In each directory, a dosbox.bat file must contain the command line to run the game.
+
+For example :
+miniputt.pc/
+miniputt.pc/dosbox.bat
+miniputt.pc/MP.DAT
+miniputt.pc/MP.EXE
+
+and dosbox.bat contains : MP.EXE
+
+Vous pouvez télécharger les jeux dos à l'adresse :
+You can download dos games on myabandonware :
+http://www.myabandonware.com/browse/platform/dos/

--- a/board/recalbox/fsoverlay/recalbox/share_init/roms/pc/_readme.txt
+++ b/board/recalbox/fsoverlay/recalbox/share_init/roms/pc/_readme.txt
@@ -13,6 +13,8 @@ miniputt.pc/MP.EXE
 
 and dosbox.bat contains : MP.EXE
 
+To quit a game, press ctrl+f9.
+
 Vous pouvez télécharger les jeux dos à l'adresse :
 You can download dos games on myabandonware :
 http://www.myabandonware.com/browse/platform/dos/


### PR DESCRIPTION
i kept the name "pc" as in the emulationstation system config file, but perhaps that all should be renamed "dos".

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
