### PR TITLE
x86: fix the keyboard

### DIFF
--- a/board/recalbox/fsoverlay_x86/etc/X11/xinit/xinitrc
+++ b/board/recalbox/fsoverlay_x86/etc/X11/xinit/xinitrc
@@ -2,6 +2,15 @@
 
 matchbox-window-manager -use_titlebar no -use_cursor no -use_desktop_mode no -use_lowlight no &
 
+# set the keyboard
+systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.pyc"
+settings_lang="`$systemsetting -command load -key system.language`"
+
+# not always true (en_US for us), but it's really better than always english
+map_name=$(echo $settings_lang | cut -c 1-2)
+setxkbmap "${map_name}"
+
+#
 export HOME=/recalbox/share/system
 export LC_ALL="${settings_lang}.UTF-8"
 

--- a/board/recalbox/x86/patches/sdl2/sdl2_input_p005_no-x11-utf8.patch
+++ b/board/recalbox/x86/patches/sdl2/sdl2_input_p005_no-x11-utf8.patch
@@ -1,0 +1,16 @@
+diff --git a/src/video/x11/SDL_x11events.c b/src/video/x11/SDL_x11events.c
+index 2080096..c978e81 100644
+--- a/src/video/x11/SDL_x11events.c
++++ b/src/video/x11/SDL_x11events.c
+@@ -40,6 +40,11 @@
+ 
+ #include <stdio.h>
+ 
++// if no input method server is available (ie ibus),
++// we must not use XIM functions. This is done by disabling
++// the ifdef X_HAVE_UTF8_STRING is this file
++#undef X_HAVE_UTF8_STRING
++
+ /*#define DEBUG_XEVENTS*/
+ 
+ #ifndef _NET_WM_MOVERESIZE_SIZE_TOPLEFT


### PR DESCRIPTION
pressing a key on a keyboard to display a letter is a complex action ;
mainly to support special chars, like keys that you can't have by pressing
a simple key, like chineese keys.
Under X, there is generally a server, an input method server, such as ibus
to handle that.
Unfortunally, such server have a lot of dependancies, and is not by default
in buildroot.
If no such server exists, kodi fall back to a more basic system not supporting
some keys. SDL requires a such server to run with X11 ; except if your X11
implementation doesn't support UTF-8... or if you make it think it doesn't via
a basic patch.

... several readings, but finally only one line to fix ;-)
note that special chars, like french accents doesn't work. I think an IM
is required to get them working.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
