### PR TITLE
sdl2_jstest : display the /dev/input/eventX

### DIFF
--- a/package/jstest2/003-display-event.patch
+++ b/package/jstest2/003-display-event.patch
@@ -1,0 +1,12 @@
+diff --git a/sdl2-jstest.c b/sdl2-jstest.c
+index 4bc2dfd..5c76a8c 100644
+--- a/sdl2-jstest.c
++++ b/sdl2-jstest.c
+@@ -65,6 +65,7 @@ void print_joystick_info(int joy_idx, SDL_Joystick* joy, SDL_GameController* gam
+   SDL_JoystickGetGUIDString(guid, guid_str, sizeof(guid_str));
+ 
+   printf("Joystick Name:     '%s'\n", SDL_JoystickName(joy));
++  printf("Joystick Path:     '%s'\n", SDL_JoystickDevicePathById(joy_idx));
+   printf("Joystick GUID:     %s\n", guid_str);
+   printf("Joystick Number:   %2d\n", joy_idx);
+   printf("Number of Axes:    %2d\n", SDL_JoystickNumAxes(joy));


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
- sdl2_jstest now displays the evpath. For ex : `Joystick Path:     '/dev/input/event2'`

Related to (put here the others PR in other repositories)
