### PR TITLE
[4.0] Delete 8bitdo Gamepads USB configuration

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/share_init/system/.emulationstation/es_input.cfg
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/.emulationstation/es_input.cfg
@@ -405,22 +405,6 @@
         <input name="x" type="button" id="2" value="1" code="290" />
         <input name="y" type="button" id="3" value="1" code="291" />
     </inputConfig>
-    <!-- 8bitdo FC30 USB -->
-    <inputConfig type="joystick" deviceName="FC30               FC30  Joystick" deviceGUID="030000003512000011ab000010010000">
-        <input name="a" type="button" id="1" value="1" code="289" />
-        <input name="b" type="button" id="2" value="1" code="290" />
-        <input name="down" type="axis" id="1" value="1" code="1" />
-        <input name="hotkey" type="button" id="6" value="1" code="294" />
-        <input name="left" type="axis" id="0" value="-1" code="0" />
-        <input name="pagedown" type="button" id="5" value="1" code="293" />
-        <input name="pageup" type="button" id="4" value="1" code="292" />
-        <input name="right" type="axis" id="0" value="1" code="0" />
-        <input name="select" type="button" id="6" value="1" code="294" />
-        <input name="start" type="button" id="7" value="1" code="295" />
-        <input name="up" type="axis" id="1" value="-1" code="1" />
-        <input name="x" type="button" id="0" value="1" code="288" />
-        <input name="y" type="button" id="3" value="1" code="291" />
-    </inputConfig>
     <!-- 8bitdo FC30 Bluetooth -->
     <inputConfig type="joystick" deviceName="Bluetooth Wireless Controller   " deviceGUID="05000000102800000900000000010000">
         <input name="a" type="button" id="170" value="1" code="304" />
@@ -436,22 +420,6 @@
         <input name="up" type="axis" id="1" value="-1" code="1" />
         <input name="x" type="button" id="173" value="1" code="307" />
         <input name="y" type="button" id="174" value="1" code="308" />
-    </inputConfig>
-    <!-- 8bitdo SFC30 USB -->
-    <inputConfig type="joystick" deviceName="SFC30              SFC30 Joystick" deviceGUID="030000003512000021ab000010010000">
-        <input name="a" type="button" id="0" value="1" code="288" />
-        <input name="b" type="button" id="1" value="1" code="289" />
-        <input name="down" type="axis" id="1" value="1" code="1" />
-        <input name="hotkey" type="button" id="10" value="1" code="298" />
-        <input name="left" type="axis" id="0" value="-1" code="0" />
-        <input name="pagedown" type="button" id="7" value="1" code="295" />
-        <input name="pageup" type="button" id="6" value="1" code="294" />
-        <input name="right" type="axis" id="0" value="1" code="0" />
-        <input name="select" type="button" id="10" value="1" code="298" />
-        <input name="start" type="button" id="11" value="1" code="299" />
-        <input name="up" type="axis" id="1" value="-1" code="1" />
-        <input name="x" type="button" id="3" value="1" code="291" />
-        <input name="y" type="button" id="4" value="1" code="292" />
     </inputConfig>
     <!-- 8bitdo SFC30 Bluetooth -->
     <inputConfig type="joystick" deviceName="Bluetooth Wireless Controller   " deviceGUID="05000000102800000900000000010000">
@@ -469,12 +437,12 @@
         <input name="x" type="button" id="173" value="1" code="307" />
         <input name="y" type="button" id="174" value="1" code="308" />
     </inputConfig>
-    <!-- 8Bitdo NES30 Pro USB -->
-    <inputConfig type="joystick" deviceName="8Bitdo NES30 Pro   8Bitdo NES30 Pro" deviceGUID="03000000022000000090000011010000">
+    <!-- 8bitdo NES30 Pro Bluetooth -->
+    <inputConfig type="joystick" deviceName="Bluetooth Wireless Controller   " deviceGUID="05000000203800000900000000010000">
         <input name="a" type="button" id="0" value="1" code="304" />
         <input name="b" type="button" id="1" value="1" code="305" />
         <input name="down" type="hat" id="0" value="4" code="16" />
-        <input name="hotkey" type="button" id="10" value="1" code="314" />
+        <input name="hotkey" type="button" id="13" value="1" code="317" />
         <input name="joystick1left" type="axis" id="0" value="-1" code="0" />
         <input name="joystick1up" type="axis" id="1" value="-1" code="1" />
         <input name="joystick2left" type="axis" id="2" value="-1" code="2" />
@@ -493,54 +461,6 @@
         <input name="x" type="button" id="3" value="1" code="307" />
         <input name="y" type="button" id="4" value="1" code="308" />
     </inputConfig>
-    <!-- 8bitdo NES30 Pro Bluetooth -->
-    <inputConfig type="joystick" deviceName="Bluetooth Wireless Controller   " deviceGUID="05000000203800000900000000010000">
-        <input name="a" type="button" id="170" value="1" code="304" />
-        <input name="b" type="button" id="171" value="1" code="305" />
-        <input name="down" type="hat" id="0" value="4" code="16" />
-        <input name="hotkey" type="button" id="180" value="1" code="314" />
-        <input name="joystick1left" type="axis" id="0" value="-1" code="0" />
-        <input name="joystick1up" type="axis" id="1" value="-1" code="1" />
-        <input name="joystick2left" type="axis" id="2" value="-1" code="2" />
-        <input name="joystick2up" type="axis" id="3" value="-1" code="5" />
-        <input name="l2" type="button" id="178" value="1" code="312" />
-        <input name="l3" type="button" id="183" value="1" code="317" />
-        <input name="left" type="hat" id="0" value="8" code="16" />
-        <input name="pagedown" type="button" id="177" value="1" code="311" />
-        <input name="pageup" type="button" id="176" value="1" code="310" />
-        <input name="r2" type="button" id="179" value="1" code="313" />
-        <input name="r3" type="button" id="184" value="1" code="318" />
-        <input name="right" type="hat" id="0" value="2" code="16" />
-        <input name="select" type="button" id="180" value="1" code="314" />
-        <input name="start" type="button" id="181" value="1" code="315" />
-        <input name="up" type="hat" id="0" value="1" code="16" />
-        <input name="x" type="button" id="173" value="1" code="307" />
-        <input name="y" type="button" id="174" value="1" code="308" />
-    </inputConfig>
-    <!-- 8Bitdo FC30 Pro USB -->
-    <inputConfig type="joystick" deviceName="8Bitdo NES30 Pro   8Bitdo NES30 Pro" deviceGUID="03000000021000000090000011010000">
-        <input name="a" type="button" id="0" value="1" />
-        <input name="b" type="button" id="1" value="1" />
-        <input name="down" type="hat" id="0" value="4" />
-        <input name="hotkey" type="button" id="10" value="1" />
-        <input name="joystick1left" type="axis" id="0" value="-1" />
-        <input name="joystick1up" type="axis" id="1" value="-1" />
-        <input name="joystick2left" type="axis" id="2" value="-1" />
-        <input name="joystick2up" type="axis" id="3" value="-1" />
-        <input name="l2" type="button" id="8" value="1" />
-        <input name="l3" type="button" id="13" value="1" />
-        <input name="left" type="hat" id="0" value="8" />
-        <input name="pagedown" type="button" id="7" value="1" />
-        <input name="pageup" type="button" id="6" value="1" />
-        <input name="r2" type="button" id="9" value="1" />
-        <input name="r3" type="button" id="14" value="1" />
-        <input name="right" type="hat" id="0" value="2" />
-        <input name="select" type="button" id="10" value="1" />
-        <input name="start" type="button" id="11" value="1" />
-        <input name="up" type="hat" id="0" value="1" />
-        <input name="x" type="button" id="3" value="1" />
-        <input name="y" type="button" id="4" value="1" />
-    </inputConfig>
     <!-- 8Bitdo Zero GamePad Bluetooth -->
     <inputConfig type="joystick" deviceName="Bluetooth Wireless Controller" deviceGUID="05000000a00500003232000001000000">
         <input name="a" type="button" id="171" value="1" code="305" />
@@ -556,28 +476,6 @@
         <input name="up" type="axis" id="1" value="-1" code="1" />
         <input name="x" type="button" id="174" value="1" code="308" />
         <input name="y" type="button" id="173" value="1" code="307" />
-    </inputConfig>
-    <!-- 8bitdo FC30 Joystick USB -->
-    <!--
-    Y X L1 L2
-    B A R1 R2
-    -->
-    <inputConfig type="joystick" deviceName="8Bitdo JoyStick    8Bitdo Joy    " deviceGUID="03000000008000000210000011010000">
-        <input name="a" type="button" id="1" value="1" code="305" />
-        <input name="b" type="button" id="0" value="1" code="304" />
-        <input name="down" type="axis" id="1" value="1" code="1" />
-        <input name="hotkey" type="button" id="10" value="1" code="314" />
-        <input name="l2" type="button" id="6" value="1" code="310" />
-        <input name="left" type="axis" id="0" value="-1" code="0" />
-        <input name="pagedown" type="button" id="9" value="1" code="313" />
-        <input name="pageup" type="button" id="7" value="1" code="311" />
-        <input name="r2" type="button" id="8" value="1" code="312" />
-        <input name="right" type="axis" id="0" value="1" code="0" />
-        <input name="select" type="button" id="10" value="1" code="314" />
-        <input name="start" type="button" id="11" value="1" code="315" />
-        <input name="up" type="axis" id="1" value="-1" code="1" />
-        <input name="x" type="button" id="4" value="1" code="308" />
-        <input name="y" type="button" id="3" value="1" code="307" />
     </inputConfig>
     <!-- 8bitdo FC30 Joystick Bluetooth -->
     <!--


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [ ] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes https://github.com/recalbox/recalbox-os/issues/1087

Changes :
- For 8bitdo gamepads to work over USB, the user will need to configure them through ES. The standard will be a Bluetooth connection, which remains. This avoids the conflict for the gamepad sending double signals when connected through USB, as the controller doesn't stop emitting when plugged in.
