### PR TITLE
c2: make the infra red to work

### DIFF
--- a/board/recalbox/fsoverlay_odroid_c2/etc/init.d/S25lircd
+++ b/board/recalbox/fsoverlay_odroid_c2/etc/init.d/S25lircd
@@ -6,13 +6,7 @@
 #
 
 loadModules() {
-    if grep -qE '^dtoverlay=lirc-rpi$' /boot/config.txt
-    then
-	if ! lsmod | grep -qE '^lirc-rpi'
-	then
-	    modprobe lirc-rpi
-	fi
-    fi
+    modprobe meson-ir
 }
 
 unloadModules() {

--- a/board/recalbox/fsoverlay_rpi_all/etc/init.d/S25lircd
+++ b/board/recalbox/fsoverlay_rpi_all/etc/init.d/S25lircd
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# Start lirc
+#
+# Support for remotes - Add remotes to /etc/lirc/lircd.conf.d/
+#
+
+loadModules() {
+    # rpi
+    if grep -qE '^dtoverlay=lirc-rpi$' /boot/config.txt
+    then
+	if ! lsmod | grep -qE '^lirc-rpi'
+	then
+	    modprobe lirc-rpi
+	fi
+    fi
+}
+
+unloadModules() {
+    if lsmod | grep -qE '^lirc-rpi'
+    then
+	rmmod lirc-rpi
+    fi
+}
+
+start() {
+	echo -n "Starting lirc: "
+	loadModules
+	mkdir -p /var/run/lirc
+	start-stop-daemon -b -S -q -m -p /var/run/lirc.pid --exec /usr/sbin/lircd -- -n --driver=default --device=/dev/lirc0 --output=/var/run/lirc/lircd --pidfile=/var/run/lirc/lircd-lirc0.pid /recalbox/share/system/.config/lirc/lircd.conf
+	echo "OK"
+}
+
+stop() {
+	echo -n "Stopping lirc: "
+	unloadModules
+	start-stop-daemon -K -q -p /var/run/lirc.pid
+	echo "OK"
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  restart|reload)
+	stop
+	start
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?


### PR DESCRIPTION
you can follow https://github.com/recalbox/recalbox-os/wiki/Infra-red-remote-control-on-the-Recalbox-%28EN%29 except part A config.txt to configure it.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
