### PR TITLE
DB9 : load the ko the right way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unrelease][unreleased]
 - Reenable mp3 support for SDL2 mixer.
+- Solve the loading of the DB9 driver
+- N64 configgen shouldn't crash anymore if some keys are not mapped
 
 ## [4.0.0-beta5] - 2016-08-13
 - Updated libretro mame 2003 core. Fixes the ratio issue in mame.

--- a/board/recalbox/fsoverlay/etc/init.d/S26recalboxsystem
+++ b/board/recalbox/fsoverlay/etc/init.d/S26recalboxsystem
@@ -49,7 +49,7 @@ rb_gpio_configure() {
 	# mk disabled let's check for db9
 	settings_db9="`$systemsetting -command load -key controllers.db9.enabled`"
 	if [ "$settings_db9" == "1" ];then
-            settings_db9_map="`$systemsetting -command load -key db9_args`"
+            settings_db9_map="`$systemsetting -command load -key controllers.db9.args`"
             recallog "enabling db9"
             eval $config_script "module" "load" db9_gpio_rpi "$settings_db9_map" >> $log
 	else 


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes the non loading of the DB9 ko

Changes :
- Added the changelog for an old configgen PR at the same time

Related to (put here the others PR in other repositories)

the option for DB9 args was wrong, causing the module not to load as expected. See https://forum.recalbox.com/topic/4377/manette-megadrive-par-db9-gpio/
