### PR TITLE
S31 : replace LC_ALL by LANG to have a less verbose output

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/recalbox/fsoverlay/etc/init.d/S31emulationstation
@@ -14,7 +14,7 @@ case "$1" in
 		[ $? = "0" ] && tvservice -e "$videoMode"
 		settings_lang="`$systemsetting -command load -key system.language`"
         	recallog "starting emulationstation with lang = $settings_lang"
-                command="HOME=/recalbox/share/system LC_ALL=\"${settings_lang}.UTF-8\" SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so SDL_VIDEO_EGL_DRIVER=/usr/lib/libGLESv2.so SDL_NOMOUSE=1 /usr/bin/emulationstation"
+                command="HOME=/recalbox/share/system LANG=\"${settings_lang}.UTF-8\" SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so SDL_VIDEO_EGL_DRIVER=/usr/lib/libGLESv2.so SDL_NOMOUSE=1 /usr/bin/emulationstation"
         	recallog "Starting emulationstation with command : "
         	recallog "$command"
         	eval $command >> $log &


### PR DESCRIPTION
Please make sure your PR is ready to be merged !
- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX
## Changes :
## 
- 

Related to (put here the others PR in other repositories)

@nadenislamarre used that for some keyboard problems in text inputs
now there is the OSK, so even if the new locale method breaks the keyboard (so far it didn't happen to me)
there is still the OSK !
this PR removes all the setocale warnings when using S31 on a console. They are quite troublesome when asking for some outputs from users
