### PR TITLE
updated gliden64 libretro core

### DIFF
--- a/package/libretro-glupen64/libretro-glupen64.mk
+++ b/package/libretro-glupen64/libretro-glupen64.mk
@@ -3,22 +3,17 @@
 # GLUPEN64
 #
 ################################################################################
-LIBRETRO_GLUPEN64_VERSION = 211792edaabaee76a51b69d4cf077a17e422f816
+LIBRETRO_GLUPEN64_VERSION = ebd1793426bc9bd28f417e1a9f5fd6f953ac67a1
 LIBRETRO_GLUPEN64_SITE = $(call github,loganmc10,GLupeN64,$(LIBRETRO_GLUPEN64_VERSION))
 LIBRETRO_GLUPEN64_GIT = https://github.com/loganmc10/GLupeN64.git
 LIBRETRO_GLUPEN64_DEPENDENCIES = rpi-userland
-
-# Reused the dirty hack form PPSPP package to download submodules
-define LIBRETRO_GLUPEN64_EXTRACT_CMDS
-	rm -rf $(@D)
-	git clone --recursive --depth 1 $(LIBRETRO_GLUPEN64_GIT) $(@D)
-	touch $(@D)/.stamp_downloaded
-endef
 
 ifeq ($(BR2_PACKAGE_RECALBOX_TARGET_RPI3),y)
 	LIBRETRO_GLUPEN64_PLATFORM=rpi3
 else ifeq ($(BR2_PACKAGE_RECALBOX_TARGET_RPI2),y)
 	LIBRETRO_GLUPEN64_PLATFORM=rpi2
+else
+	LIBRETRO_GLUPEN64_PLATFORM="$(LIBRETRO_PLATFORM)"
 endif
 
 define LIBRETRO_GLUPEN64_BUILD_CMDS
@@ -31,8 +26,8 @@ define LIBRETRO_GLUPEN64_INSTALL_TARGET_CMDS
 endef
 
 define GLUPEN64_CROSS_FIXUP
-        $(SED) 's|/opt/vc/include|$(STAGING_DIR)/usr/include|g' $(@D)/Makefile
-        $(SED) 's|/opt/vc/lib|$(STAGING_DIR)/usr/lib|g' $(@D)/Makefile
+	$(SED) 's|/opt/vc/include|$(STAGING_DIR)/usr/include|g' $(@D)/Makefile
+	$(SED) 's|/opt/vc/lib|$(STAGING_DIR)/usr/lib|g' $(@D)/Makefile
 endef
 
 GLUPEN64_PRE_CONFIGURE_HOOKS += GLUPEN64_FIXUP


### PR DESCRIPTION
Please make sure your PR is ready to be merged !

- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Changes :
- updated glupen64 libretro core and removed the hack to download submodules. The github repo don't use it anymore.

@nadenislamarre This libretro core need to be tested on odroids & x86 platforms.
It works pretty well on rpi3.
If this core works on x86, maybe provide in the future 2 versions, one built with GLES2 support and another one with GLES3 support.


