### PR TITLE
ppsspp : HK can quit

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/share_init/system/configs/ppsspp/PSP/SYSTEM/controls.ini
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/configs/ppsspp/PSP/SYSTEM/controls.ini
@@ -19,5 +19,5 @@ Analog limiter = 1-60
 RapidFire = 1-59
 Unthrottle = 1-61
 SpeedToggle = 1-68
-Pause = 1-111
+Pause = 1-111,10-4
 Rewind = 1-67


### PR DESCRIPTION
Please make sure your PR is ready to be merged !

- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
Since the PPSSPP bump for C2 and its new configgen, the `--escape-exit` was broken. This commit is a workaround
The P1 Hotkey will always be 10-4, whichever pad is plugged, as long as it has a hotkey
See https://github.com/hrydgard/ppsspp/issues/9119