### PR TITLE
recalbox-upgrade.sh: fix grep -P as it's unknown to the BusyBox grep

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-upgrade.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-upgrade.sh
@@ -30,7 +30,7 @@ for file in $files; do
     recallog -e "Unable to get headers for ${url}"
     exit 2
   fi
-  filesize=`echo "$headers" | grep "Content-Length: " | grep -Po '\d+'`
+  filesize=`echo "$headers" | grep "Content-Length: " | grep -Eo '[0-9]+'`
   if [ $? -ne 0 ];then
     recallog -e "Unable to get size from headers ${url}"
     exit 3


### PR DESCRIPTION
Please make sure your PR is ready to be merged !

- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes #XXXX

Changes :
- replace grep -Po + number class by grep -Eo + number range

Related to (put here the others PR in other repositories)
