### PR TITLE
Update moonlight-embedded.mk

### DIFF
--- a/package/moonlight-embedded/moonlight-embedded.mk
+++ b/package/moonlight-embedded/moonlight-embedded.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MOONLIGHT_EMBEDDED_VERSION = 2.2.2
+MOONLIGHT_EMBEDDED_VERSION = 2.2.3
 MOONLIGHT_EMBEDDED_SOURCE = moonlight-embedded-$(MOONLIGHT_EMBEDDED_VERSION).tar.xz
 MOONLIGHT_EMBEDDED_SITE = https://github.com/irtimmer/moonlight-embedded/releases/download/v$(MOONLIGHT_EMBEDDED_VERSION)
 MOONLIGHT_EMBEDDED_DEPENDENCIES = opus expat libevdev avahi alsa-lib udev libcurl libcec ffmpeg sdl2 libenet


### PR DESCRIPTION
Moonlight Embedded 2.2.3 updated version to support GFE 3.2

- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes https://github.com/recalbox/recalbox-os/issues/1147

Changes :
- Moonlight Embedded 2.2.3 updated version to support GFE 3.2
- 
- 

Related to (put here the others PR in other repositories)
