### PR TITLE
Retroarch: Fix compiling when using musl

### DIFF
--- a/package/retroarch/retroarch-003-musl-compile-fix.patch
+++ b/package/retroarch/retroarch-003-musl-compile-fix.patch
@@ -1,0 +1,11 @@
+--- a/libretro-common/include/streams/interface_stream.h	2017-01-10 07:26:42.573804504 +0100
++++ b/libretro-common/include/streams/interface_stream.h	2017-01-10 07:27:04.685887493 +0100
+@@ -25,6 +25,7 @@
+ 
+ #include <stdint.h>
+ #include <stddef.h>
++#include <sys/types.h>
+ 
+ #include <retro_common_api.h>
+ #include <boolean.h>
+


### PR DESCRIPTION
Please make sure your PR is ready to be merged !

- [ ] You added the changes in CHANGELOG.md
- [X] You choose the right repository branch to make the PR
- [ ] You described the PR as below

Fixes [https://github.com/recalbox/recalbox-os/issues/1165]

Changes :
-  Package "Retroarch": Add missing headers for MUSL
- 
- 

Related to (put here the others PR in other repositories)

Description :
When selecting "musl" as glibc the package "Retroarch" cant compiled. Adding the missing headers fixes the problem. 

```
In file included from libretro-common/streams/interface_stream.c:25:0:
./libretro-common/include/streams/interface_stream.h:62:40: Fehler: unbekannter Typname: »ssize_t«
       const char *path, unsigned mode, ssize_t len);
                                        ^
./libretro-common/include/streams/interface_stream.h:64:1: Fehler: unbekannter Typname: »ssize_t«
 ssize_t intfstream_read(intfstream_internal_t *intf,
 ^
./libretro-common/include/streams/interface_stream.h:67:1: Fehler: unbekannter Typname: »ssize_t«
 ssize_t intfstream_write(intfstream_internal_t *intf,
 ^
Makefile:137: die Regel für Ziel „obj-unix/libretro-common/streams/interface_stream.o“ scheiterte

```