### PR TITLE
Recalbox: Only build kodi packages when kodi is selected

### DIFF
--- a/package/kodi-plugin-video-filmon/Config.in
+++ b/package/kodi-plugin-video-filmon/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_PLUGIN_VIDEO_FILMON
+    depends on BR2_PACKAGE_KODI
     bool "kodi-plugin-video-filmon"
     default y
     select BR2_PACKAGE_KODI_SCRIPT_MODULE_T0MM0_COMMON

--- a/package/kodi-plugin-video-youtube/Config.in
+++ b/package/kodi-plugin-video-youtube/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_PLUGIN_VIDEO_YOUTUBE
+    depends on BR2_PACKAGE_KODI
     bool "kodi-plugin-video-youtube"
     default y
     help

--- a/package/kodi-resource-language-de_de/Config.in
+++ b/package/kodi-resource-language-de_de/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_de_de
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-de_de"
     default y
     help

--- a/package/kodi-resource-language-es_es/Config.in
+++ b/package/kodi-resource-language-es_es/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_es_es
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-es_es"
     default y
     help

--- a/package/kodi-resource-language-eu_es/Config.in
+++ b/package/kodi-resource-language-eu_es/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_eu_es
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-eu_es"
     default y
     help

--- a/package/kodi-resource-language-fr_fr/Config.in
+++ b/package/kodi-resource-language-fr_fr/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_fr_fr
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-fr_fr"
     default y
     help

--- a/package/kodi-resource-language-it_it/Config.in
+++ b/package/kodi-resource-language-it_it/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_it_it
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-it_it"
     default y
     help

--- a/package/kodi-resource-language-pt_br/Config.in
+++ b/package/kodi-resource-language-pt_br/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_pt_br
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-pt_br"
     default y
     help

--- a/package/kodi-resource-language-sv_se/Config.in
+++ b/package/kodi-resource-language-sv_se/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_sv_se
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-sv_se"
     default y
     help

--- a/package/kodi-resource-language-tr_tr/Config.in
+++ b/package/kodi-resource-language-tr_tr/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_tr_tr
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-tr_tr"
     default y
     help

--- a/package/kodi-resource-language-zh_cn/Config.in
+++ b/package/kodi-resource-language-zh_cn/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_RESOURCE_LANGUAGE_zh_cn
+    depends on BR2_PACKAGE_KODI
     bool "kodi-resource-language-zh_cn"
     default y
     help

--- a/package/kodi-script.module.t0mm0.common/Config.in
+++ b/package/kodi-script.module.t0mm0.common/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_SCRIPT_MODULE_T0MM0_COMMON
+    depends on BR2_PACKAGE_KODI
     bool "kodi-script.module.t0mm0.common"
     default y
     help

--- a/package/kodi-superrepo-all/Config.in
+++ b/package/kodi-superrepo-all/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_SUPERREPO_ALL
+    depends on BR2_PACKAGE_KODI
     bool "kodi-superrepo-all"
     default y
     help

--- a/package/kodi-superrepo-repositories/Config.in
+++ b/package/kodi-superrepo-repositories/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_SUPERREPO_REPOSITORIES
+    depends on BR2_PACKAGE_KODI
     bool "kodi-superrepo-repositories"
     default y
     help

--- a/package/kodi-visualisation-fishbmc/Config.in
+++ b/package/kodi-visualisation-fishbmc/Config.in
@@ -1,5 +1,6 @@
 config BR2_PACKAGE_KODI_VISUALISATION_FISHBMC
 	bool "kodi-visualisation-fishbmc"
+    depends on BR2_PACKAGE_KODI
 	depends on BR2_PACKAGE_HAS_LIBGL
 	help
 	  Fische visualiser for Kodi

--- a/package/kodi-visualisation-fountain/Config.in
+++ b/package/kodi-visualisation-fountain/Config.in
@@ -1,5 +1,6 @@
 config BR2_PACKAGE_KODI_VISUALISATION_FOUNTAIN
 	bool "kodi-visualisation-fountain"
+    depends on BR2_PACKAGE_KODI
 	depends on BR2_PACKAGE_HAS_LIBGL # libsoil
 	select BR2_PACKAGE_LIBSOIL
 	help

--- a/package/kodi-visualisation-goom/Config.in
+++ b/package/kodi-visualisation-goom/Config.in
@@ -1,5 +1,6 @@
 config BR2_PACKAGE_KODI_VISUALISATION_GOOM
 	bool "kodi-visualisation-goom"
+    depends on BR2_PACKAGE_KODI
 	depends on BR2_PACKAGE_HAS_LIBGL
 	help
 	  GOOM visualiser for Kodi

--- a/package/kodi-visualisation-shadertoy/Config.in
+++ b/package/kodi-visualisation-shadertoy/Config.in
@@ -1,5 +1,6 @@
 config BR2_PACKAGE_KODI_VISUALISATION_SHADERTOY
 	bool "kodi-visualisation-shadertoy"
+    depends on BR2_PACKAGE_KODI
 	select BR2_PACKAGE_LIBGLEW if BR2_PACKAGE_HAS_LIBGL
 	select BR2_PACKAGE_LIBPLATFORM
 	help

--- a/package/kodi-visualisation-spectrum/Config.in
+++ b/package/kodi-visualisation-spectrum/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_VISUALISATION_SPECTRUM
+    depends on BR2_PACKAGE_KODI
 	bool "kodi-visualisation-spectrum"
 	help
 	  Spectrum visualiser for Kodi

--- a/package/kodi-visualisation-waveforhue/Config.in
+++ b/package/kodi-visualisation-waveforhue/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_VISUALISATION_WAVEFORHUE
+    depends on BR2_PACKAGE_KODI
 	bool "kodi-visualisation-waveforhue"
 	help
 	  WaveForHue visualiser for Kodi

--- a/package/kodi-visualisation-waveform/Config.in
+++ b/package/kodi-visualisation-waveform/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KODI_VISUALISATION_WAVEFORM
+    depends on BR2_PACKAGE_KODI
 	bool "kodi-visualisation-waveform"
 	help
 	  Waveform visualiser for Kodi


### PR DESCRIPTION
Please make sure your PR is ready to be merged !

- [ ] You added the changes in CHANGELOG.md
- [X] You choose the right repository branch to make the PR
- [X] You described the PR as below

Fixes #XXXX

Changes :
- Do not compile KODI addons when KODI is not selected.

Description :
This PR fixed a bug where kodi addons gets selected when kodi isnt it.