### PR TITLE
recalbox-config.sh: fix crash when setting sound

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-config.sh
@@ -269,13 +269,18 @@ fi
 
 if [ "$command" == "volume" ];then
 	if [ "$mode" != "" ];then
-        	echo "`logtime` : setting audio volume : $mode" >> $log
-
+		echo "`logtime` : setting audio volume : $mode" >> $log
+		
+		if ( amixer scontrols | grep -q 'Master' ); then
 		# on my pc, the master is turned off at boot
 		# i don't know what are the rules to set here.
-		amixer set Master unmute      || exit 1
-                amixer set Master -- ${mode}% || exit 1
-		amixer set PCM    -- ${mode}% || exit 1
+			amixer set Master unmute      || exit 1
+			amixer set Master -- ${mode}% || exit 1
+		fi
+		if ( amixer scontrols | grep -q 'PCM' ); then
+			amixer set PCM    -- ${mode}% || exit 1
+		fi
+		# Odroids have no sound controller. Too bad, exit 0 anyway
 		exit 0
 	fi
 	exit 12


### PR DESCRIPTION
Bug was added with 994ab8c6467a0e11e0e603aafbc3c01744711bbe as:
- Pi don't have a 'Master' channel
- Odroid onboard sound can't be set with alsa

The bug was found while testing @DjLeChuck 's web manager

Please make sure your PR is ready to be merged !

- [ ] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Fixes https://github.com/DjLeChuck/recalbox-manager/issues/16