### PR TITLE
set kodi to be executed as kodi user

### DIFF
--- a/board/recalbox/fsoverlay/etc/udev/rules.d/10-hiddev-permissions.rules
+++ b/board/recalbox/fsoverlay/etc/udev/rules.d/10-hiddev-permissions.rules
@@ -1,0 +1,1 @@
+KERNEL=="hiddev*",GROUP="input",MODE="0660"

--- a/board/recalbox/fsoverlay/etc/udev/rules.d/10-vchiq-permissions.rules
+++ b/board/recalbox/fsoverlay/etc/udev/rules.d/10-vchiq-permissions.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="vchiq",GROUP="video",MODE="0660"

--- a/board/recalbox/fsoverlay/recalbox/scripts/kodilauncher.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/kodilauncher.sh
@@ -46,7 +46,7 @@ then
 fi
 
 (
-    LD_LIBRARY_PATH="/usr/lib/mysql" /usr/lib/kodi/kodi.bin --standalone -fs
+    su - kodi -c "LD_LIBRARY_PATH=/usr/lib/mysql usr/lib/kodi/kodi.bin --standalone -fs"
     echo "Kodi process ended." >&2
     echo "EXIT" >> /var/run/kodi.msg # in case of normal, but mainly anormal end of kodi, send a message to signal the end
 )&

--- a/board/recalbox/user-table.txt
+++ b/board/recalbox/user-table.txt
@@ -1,0 +1,1 @@
+kodi 499 kodi 499 !=kodipassword /recalbox/share/system/ /bin/sh tty,video,audio,input Kodi user

--- a/configs/recalbox-rpi1_defconfig
+++ b/configs/recalbox-rpi1_defconfig
@@ -21,6 +21,7 @@ BR2_ENABLE_LOCALE_WHITELIST="C ar ca de el es eu_ES fr it ko nb_NO nl no pl pt s
 BR2_GENERATE_LOCALE="en_US.UTF-8 ar_YE.UTF-8 ca_ES.UTF-8 de_DE.UTF-8 el_GR.UTF-8 es_ES.UTF-8 eu_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ko_KR.UTF-8 nb_NO.UTF-8 nn_NO.UTF-8 nl_NL.UTF-8 pl_PL.UTF-8 pt_BR.UTF-8 sv_SE.UTF-8 tr_TR.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
 BR2_TARGET_TZ_INFO=y
 BR2_TARGET_LOCALTIME="Europe/Paris"
+BR2_ROOTFS_USERS_TABLES="board/recalbox/user-table.txt"
 BR2_ROOTFS_OVERLAY="board/recalbox/fsoverlay board/recalbox/rpi/fsoverlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="board/recalbox/recalbox-patch-target.sh"
 BR2_ROOTFS_POST_IMAGE_SCRIPT="board/recalbox/copy-recalbox-archives.sh"

--- a/configs/recalbox-rpi2_defconfig
+++ b/configs/recalbox-rpi2_defconfig
@@ -22,6 +22,7 @@ BR2_ENABLE_LOCALE_WHITELIST="C ar ca de el es eu_ES fr it ko nb_NO nl no pl pt s
 BR2_GENERATE_LOCALE="en_US.UTF-8 ar_YE.UTF-8 ca_ES.UTF-8 de_DE.UTF-8 el_GR.UTF-8 es_ES.UTF-8 eu_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ko_KR.UTF-8 nb_NO.UTF-8 nn_NO.UTF-8 nl_NL.UTF-8 pl_PL.UTF-8 pt_BR.UTF-8 sv_SE.UTF-8 tr_TR.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
 BR2_TARGET_TZ_INFO=y
 BR2_TARGET_LOCALTIME="Europe/Paris"
+BR2_ROOTFS_USERS_TABLES="board/recalbox/user-table.txt"
 BR2_ROOTFS_OVERLAY="board/recalbox/fsoverlay board/recalbox/rpi/fsoverlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="board/recalbox/recalbox-patch-target.sh"
 BR2_ROOTFS_POST_IMAGE_SCRIPT="board/recalbox/copy-recalbox-archives.sh"

--- a/configs/recalbox-rpi3_defconfig
+++ b/configs/recalbox-rpi3_defconfig
@@ -22,6 +22,7 @@ BR2_ENABLE_LOCALE_WHITELIST="C ar ca de el es eu_ES fr it ko nb_NO nl no pl pt s
 BR2_GENERATE_LOCALE="en_US.UTF-8 ar_YE.UTF-8 ca_ES.UTF-8 de_DE.UTF-8 el_GR.UTF-8 es_ES.UTF-8 eu_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 ko_KR.UTF-8 nb_NO.UTF-8 nn_NO.UTF-8 nl_NL.UTF-8 pl_PL.UTF-8 pt_BR.UTF-8 sv_SE.UTF-8 tr_TR.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
 BR2_TARGET_TZ_INFO=y
 BR2_TARGET_LOCALTIME="Europe/Paris"
+BR2_ROOTFS_USERS_TABLES="board/recalbox/user-table.txt"
 BR2_ROOTFS_OVERLAY="board/recalbox/fsoverlay board/recalbox/rpi/fsoverlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="board/recalbox/recalbox-patch-target.sh"
 BR2_ROOTFS_POST_IMAGE_SCRIPT="board/recalbox/copy-recalbox-archives.sh"


### PR DESCRIPTION
Currently, Kodi is executed as root. This PR add the ability to mount NFS share without "no_root_squash" options. This allows a fine grained permission setting on the NFS server.