### PR TITLE
Swap OK and Cancel button in retroarch menus (issue #1195)

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg.origin
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg.origin
@@ -48,3 +48,5 @@ input_enable_hotkey_btn = "16"
 
 input_enable_hotkey = "escape"
 input_exit_emulator = "escape"
+
+menu_swap_ok_cancel_buttons = "true"

--- a/board/recalbox/x86/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg.origin
+++ b/board/recalbox/x86/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg.origin
@@ -49,6 +49,8 @@ input_enable_hotkey_btn = "16"
 input_enable_hotkey = "escape"
 input_exit_emulator = "escape"
 
+menu_swap_ok_cancel_buttons = "true"
+
 # specific to x86
 video_driver = "sdl2"
 # avoid blinking borders coming sometimes


### PR DESCRIPTION
In ES we use B as OK and A as Cancel but the other way in Retroarch menus.

it would be more consistent to have the same layout in both.

menu_swap_ok_cancel_buttons = "true" option tested, working as designed.

Please make sure your PR is ready to be merged !

- [ ] You added the changes in CHANGELOG.md
- [ ] You choose the right repository branch to make the PR
- [ ] You described the PR as below

Fixes #XXXX

Changes :
- 
- 
- 

Related to (put here the others PR in other repositories)
