### PR TITLE
Update kodi-plugin-video-youtube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add ipega 9021 rules
 - Added stat in busybox
 - Added integer scale (Pixel Perfect) option
+- Update kodi-plugin-youtube
 
 ## [4.0.0-beta3] - 2016-04-19
 - Xarcade2jstick button remapped + better support of IPAC encoders

--- a/package/kodi-plugin-video-youtube/kodi_plugin_video_youtube.mk
+++ b/package/kodi-plugin-video-youtube/kodi_plugin_video_youtube.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI_PLUGIN_VIDEO_YOUTUBE_VERSION = 5.3.6
+KODI_PLUGIN_VIDEO_YOUTUBE_VERSION = 5.3.12
 KODI_PLUGIN_VIDEO_YOUTUBE_SOURCE = plugin.video.youtube-$(KODI_PLUGIN_VIDEO_YOUTUBE_VERSION).zip
 KODI_PLUGIN_VIDEO_YOUTUBE_SITE = http://ftp.halifax.rwth-aachen.de/xbmc/addons/jarvis/plugin.video.youtube
 KODI_PLUGIN_VIDEO_YOUTUBE_PLUGINNAME=plugin.video.youtube


### PR DESCRIPTION
When I compile recalbox, this plugin is not found (404 error)
The version 5.3.6 don't still exist in the repo : http://ftp.halifax.rwth-aachen.de/xbmc/addons/jarvis/plugin.video.youtube/
