### PR TITLE
Version 5.3.6 no longer available.

### DIFF
--- a/package/kodi-plugin-video-youtube/kodi_plugin_video_youtube.mk
+++ b/package/kodi-plugin-video-youtube/kodi_plugin_video_youtube.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI_PLUGIN_VIDEO_YOUTUBE_VERSION = 5.3.6
+KODI_PLUGIN_VIDEO_YOUTUBE_VERSION = 5.3.8
 KODI_PLUGIN_VIDEO_YOUTUBE_SOURCE = plugin.video.youtube-$(KODI_PLUGIN_VIDEO_YOUTUBE_VERSION).zip
 KODI_PLUGIN_VIDEO_YOUTUBE_SITE = http://ftp.halifax.rwth-aachen.de/xbmc/addons/jarvis/plugin.video.youtube
 KODI_PLUGIN_VIDEO_YOUTUBE_PLUGINNAME=plugin.video.youtube


### PR DESCRIPTION
Only 5.3.8, 5.3.10 adn 5..3.12 are available ont the website. I have build without any issues with version proposed but I'm not tested the new version of this plugins in kodi.

Please make sure your PR is ready to be merged !

- [ ] You added the changes in CHANGELOG.md
- [ ] You choose the right repository branch to make the PR
- [ ] You described the PR as below

Fixes #XXXX

Changes :
- 
- 
- 

Related to (put here the others PR in other repositories)
