### PR TITLE
Add usbhid quirk for GamepadBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add usb encoder 3H-Dual-Arcade, Mayflash dreamcast adapter
 - Add support for smb and upnp protocols in Kodi
 - Add usbhid quirk for AJ 2 USB 2.4G sans fil manettes (ShanWan Twin USB Joystick PS3)
+- Add usbhid quirk for [GamepadBlock](https://blog.petrockblock.com/gamepadblock/)
 
 ## [4.0.0-beta5] - 2016-08-13hs the ratio issue in mame.
 - Improved pads and gpio support for moonlight

--- a/board/recalbox/fsoverlay/etc/modprobe.d/usbhid.conf
+++ b/board/recalbox/fsoverlay/etc/modprobe.d/usbhid.conf
@@ -48,4 +48,5 @@ options usbhid quirks=0x16c0:0x05e0:0x040
 #ShanWan Twin USB Joystick
 options usbhid quirks=0x2563:0x555:0x040
 
-
+# GamepadBlock
+options usbhid quirks=0x16D0:0x0BCC:0x040


### PR DESCRIPTION
Fixes:
GamepadBlock is not recognised correctly during enumeration

Changes :
- Add usbhid quirk for the GamepadBlock such that two gamepads are created when connecting the GamepadBlock. The changes follow the same pattern as done for other USB twin joysticks devices in the file usbhid.conf

Related to (put here the others PR in other repositories):
-