### PR TITLE
Update recalbox-encode.sh

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/scripts/recalbox-encode.sh
+++ b/board/recalbox/fsoverlay/recalbox/scripts/recalbox-encode.sh
@@ -30,7 +30,7 @@ case "${ACTION}" in
 
     "encode")
 	PASSWORD=$(getPassword)
-	CODE=$(echo "${CODE}" | openssl enc -aes-128-cbc -a -salt -pass pass:"${PASSWORD}")
+	CODE=$(echo "${CODE}" | openssl enc -aes-128-cbc -A -a -salt -pass pass:"${PASSWORD}")
 	echo "enc:${CODE}"
     ;;
 esac


### PR DESCRIPTION
Prevent line breaks in long wifi passwords with more than 30 characters.

Changes :
- Long wifi passwords with more than 30 characters will not longer cut. 